### PR TITLE
Feat: Implement SignUp View Step1 - Terms View

### DIFF
--- a/Wastory/Wastory/Model/TermItem.swift
+++ b/Wastory/Wastory/Model/TermItem.swift
@@ -1,0 +1,22 @@
+//
+//  TermItem.swift
+//  Wastory
+//
+//  Created by mujigae on 12/30/24.
+//
+
+import Foundation
+
+struct TermItem: Identifiable {
+    var id: UUID = UUID()
+    let type: TermType
+    let term: String
+    var details: String = ""
+    var isAgreed: Bool = false
+}
+
+enum TermType: String {
+    case none
+    case required
+    case optional
+}

--- a/Wastory/Wastory/View/SignView/SignInView.swift
+++ b/Wastory/Wastory/View/SignView/SignInView.swift
@@ -137,7 +137,7 @@ struct SignInView: View {
                         .frame(height: 30)
                     
                     HStack {
-                        NavigationLink(destination: SignUpView()) {
+                        NavigationLink(destination: SignUpStep1TermsView()) {
                             Text("회원가입")
                                 .font(.system(size: 14, weight: .light))
                                 .foregroundStyle(.black)

--- a/Wastory/Wastory/View/SignView/SignUpStep1TermsView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep1TermsView.swift
@@ -1,0 +1,7 @@
+//
+//  SignUpStep1TermsView.swift
+//  Wastory
+//
+//  Created by mujigae on 12/30/24.
+//
+

--- a/Wastory/Wastory/View/SignView/SignUpStep1TermsView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep1TermsView.swift
@@ -5,3 +5,127 @@
 //  Created by mujigae on 12/30/24.
 //
 
+import SwiftUI
+
+struct SignUpStep1TermsView: View {
+    @State private var viewModel = SignUpStep1ViewModel()
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                ZStack {
+                    HStack {
+                        Rectangle()
+                            .foregroundStyle(Color.progressBarBackgroundColor)
+                            .frame(width: 60, height: 5)
+                            .cornerRadius(12)
+                            .padding(.leading, 20)
+                        Spacer()
+                    }
+                    HStack {
+                        Rectangle()
+                            .foregroundStyle(Color.progressBarProgressColor)
+                            .frame(width: 20, height: 5)
+                            .cornerRadius(12)
+                            .padding(.leading, 20)
+                        Spacer()
+                    }
+                }
+                .padding(.top, 20)
+                
+                HStack {
+                    Text("와스토리 계정")
+                        .font(.system(size: 18, weight: .regular))
+                        .padding(.horizontal, 20)
+                    Spacer()
+                }
+                .padding(.top, 24)
+                Spacer()
+                    .frame(height: 5)
+                HStack {
+                    Text("서비스 약관에 동의해 주세요.")
+                        .font(.system(size: 18, weight: .regular))
+                        .padding(.horizontal, 20)
+                    Spacer()
+                }
+                
+                Spacer()
+                    .frame(height: 24)
+                
+                HStack(alignment: .firstTextBaseline) {
+                    Image(systemName: viewModel.isEntireTermAgreed() ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(
+                            viewModel.isEntireTermAgreed() ? .black : Color.promptLabelColor,
+                            viewModel.isEntireTermAgreed() ? Color.kakaoYellow : Color.promptLabelColor
+                        )
+                        .padding(.leading, 20)
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("모두 동의합니다.")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(.black)
+                        
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("전체 동의는 필수 및 선택정보에 대한 동의도 포함되어 있으며, 개별적으로도 동의를 선택하실 수 있습니다.")
+                                .font(.system(size: 11, weight: .regular))
+                                .foregroundStyle(Color.promptLabelColor)
+                                .lineSpacing(3)
+                            Text("선택항목에 대한 동의를 거부하시는 경우에도 서비스는 이용이 가능합니다.")
+                                .font(.system(size: 11, weight: .regular))
+                                .foregroundStyle(Color.promptLabelColor)
+                                .lineSpacing(3)
+                        }
+                    }
+                    .padding(.trailing, 20)
+                    
+                    Spacer()
+                }
+                .onTapGesture {
+                    viewModel.toggleEntireAgreement()
+                }
+                
+                Spacer()
+                    .frame(height: 24)
+                Divider()
+                    .padding(.leading, 48)
+                    .padding(.trailing, 20)
+                Spacer()
+                    .frame(height: 24)
+                
+                VStack(spacing: 12) {
+                    ForEach(viewModel.getTerms()) { cell in
+                        TermCell(item: cell, term: viewModel.getTerm(item: cell))
+                            .onTapGesture {
+                                viewModel.toggleItemAgreement(item: cell)
+                            }
+                    }
+                }
+                
+                Spacer()
+                    .frame(height: 30)
+                
+                NavigationLink(destination: EmptyView()) {  // 임시로 EmptyView로 넘어감
+                    Text("동의")
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundStyle(viewModel.areAllRequiredTermsAgreed() ? .black : Color.incompleteAgreementTextColor)
+                        .padding(.vertical, 16)
+                        .frame(maxWidth: .infinity, idealHeight: 51)
+                        .background(viewModel.areAllRequiredTermsAgreed() ? Color.kakaoYellow : Color.incompleteAgreementBoxColor)
+                        .cornerRadius(6)
+                }
+                .padding(.horizontal, 20)
+                .disabled(viewModel.areAllRequiredTermsAgreed() == false)
+                
+                Spacer()
+            }
+        }
+    }
+}
+
+extension Color {
+    static let progressBarBackgroundColor: Color = .init(red: 235 / 255, green: 235 / 255, blue: 235 / 255)  // 회원가입 진행도 배경 색상
+    static let progressBarProgressColor: Color = .init(red: 76 / 255, green: 76 / 255, blue: 76 / 255)  // 회원가입 진행도 진행률 색상
+    static let incompleteAgreementBoxColor: Color = .init(red: 250 / 255, green: 250 / 255, blue: 250 / 255)  // 동의 미완료 박스 색상
+    static let incompleteAgreementTextColor: Color = .init(red: 179 / 255, green: 179 / 255, blue: 179 / 255)  // 동의 미완료 박스 색상
+}

--- a/Wastory/Wastory/View/SignView/SignUpStep1TermsView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep1TermsView.swift
@@ -105,7 +105,7 @@ struct SignUpStep1TermsView: View {
                 Spacer()
                     .frame(height: 30)
                 
-                NavigationLink(destination: EmptyView()) {  // 임시로 EmptyView로 넘어감
+                NavigationLink(destination: SignUpStep2EmailView()) {
                     Text("동의")
                         .font(.system(size: 16, weight: .regular))
                         .foregroundStyle(viewModel.areAllRequiredTermsAgreed() ? .black : Color.incompleteAgreementTextColor)

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -1,0 +1,16 @@
+//
+//  SignUpStep2EmailView.swift
+//  Wastory
+//
+//  Created by mujigae on 12/30/24.
+//
+
+import SwiftUI
+
+struct SignUpStep2EmailView: View {
+    @State private var viewModel = SignUpStep2ViewModel()
+    
+    var body: some View {
+        Text("이메일 인증 뷰")
+    }
+}

--- a/Wastory/Wastory/View/SignView/TermCell.swift
+++ b/Wastory/Wastory/View/SignView/TermCell.swift
@@ -1,0 +1,7 @@
+//
+//  TermCell.swift
+//  Wastory
+//
+//  Created by mujigae on 12/30/24.
+//
+

--- a/Wastory/Wastory/View/SignView/TermCell.swift
+++ b/Wastory/Wastory/View/SignView/TermCell.swift
@@ -5,3 +5,40 @@
 //  Created by mujigae on 12/30/24.
 //
 
+import SwiftUI
+
+struct TermCell: View {
+    let item: TermItem
+    let term: String
+    
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Image(systemName: item.isAgreed ? "checkmark.circle.fill" : "circle")
+                .font(.system(size: 16, weight: .regular))
+                .foregroundStyle(
+                    item.isAgreed ? .black : Color.promptLabelColor,
+                    item.isAgreed ? Color.kakaoYellow : Color.promptLabelColor
+                )
+            
+            if item.details.isEmpty {
+                Text(term)
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundColor(.black)
+            }
+            else {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(term)
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundColor(.black)
+                    Text(item.details)
+                        .font(.system(size: 10, weight: .regular))
+                        .foregroundStyle(Color.promptLabelColor)
+                        .lineSpacing(2)
+                }
+            }
+            
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+    }
+}

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep1ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep1ViewModel.swift
@@ -5,3 +5,89 @@
 //  Created by mujigae on 12/30/24.
 //
 
+import SwiftUI
+import Observation
+
+@Observable final class SignUpStep1ViewModel {
+    private var terms: [TermItem] = [
+        TermItem(type: .required, term: "와스토리 계정 약관"),
+        TermItem(type: .required, term: "왠지 모르게 필수적인 약관"),
+        TermItem(type: .required, term: "세부 사항이 있는 약관",
+                 details: "자세하지 않은 듯 자세한 세부 사항이며 한 줄을 넘어 줄바꿈 간격을 확인하기 위해 매우 길게 설계되었습니다."),
+        TermItem(type: .optional, term: "위치정보 수집 및 이용 동의"),
+        TermItem(type: .optional, term: "알 수 없지만 무언가 선택적인 약관")
+    ]
+    
+    private var agreedCount: Int = 0
+    private var requiredCount: Int = 0
+    private var totalRequiredCount: Int = 0
+    
+    init() {
+        for index in 0..<terms.count {
+            if terms[index].type == .required {
+                totalRequiredCount += 1
+            }
+        }
+    }
+    
+    func getTerms() -> [TermItem] {
+        return terms
+    }
+    
+    func getTerm(item: TermItem) -> String {
+        switch item.type {
+        case .none:
+            return item.term
+        case .required:
+            return "[필수] \(item.term)"
+        case .optional:
+            return "[선택] \(item.term)"
+        }
+    }
+    
+    func toggleItemAgreement(item: TermItem) {
+        if let index = terms.firstIndex(where: { $0.id == item.id }) {
+            terms[index].isAgreed.toggle()
+            if terms[index].isAgreed {
+                agreedCount += 1
+                if terms[index].type == .required {
+                    requiredCount += 1
+                }
+            }
+            else {
+                agreedCount -= 1
+                if terms[index].type == .required {
+                    requiredCount -= 1
+                }
+            }
+        }
+    }
+    
+    func toggleEntireAgreement() {
+        if agreedCount == terms.count {
+            for index in 0..<terms.count {
+                terms[index].isAgreed = false
+            }
+            agreedCount = 0
+            requiredCount = 0
+        }
+        else {
+            requiredCount = 0
+            for index in 0..<terms.count {
+                terms[index].isAgreed = true
+                if terms[index].type == .required {
+                    requiredCount += 1
+                }
+            }
+            agreedCount = terms.count
+        }
+    }
+    
+    func isEntireTermAgreed() -> Bool {
+        return agreedCount == terms.count
+    }
+    
+    func areAllRequiredTermsAgreed() -> Bool {
+        return requiredCount == totalRequiredCount
+    }
+}

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep1ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep1ViewModel.swift
@@ -1,0 +1,7 @@
+//
+//  SignUpStep1ViewModel.swift
+//  Wastory
+//
+//  Created by mujigae on 12/30/24.
+//
+

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  SignUpStep2ViewModel.swift
+//  Wastory
+//
+//  Created by mujigae on 12/30/24.
+//
+
+import SwiftUI
+import Observation
+
+@Observable final class SignUpStep2ViewModel {
+
+}


### PR DESCRIPTION
###PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[O] 기능 추가 
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

###반영 브랜치
feat/add-signup-step1-view -> main

###변경 사항
SignUpStep1TermsView, SignUpStep1ViewModel 구현 (이용 약관 화면)

###추후 보완 사항 
회원가입 과정 중 화면에 백버튼이 나오는지 확인하고 iOS에서 회원가입 시 뒤로 가기가 어떻게 작동하는지 확인 후 백버튼 보완
이메일 인증 요청 (Step2) -> 이메일 인증 확인 (Step3)로 뷰가 나뉘는 줄 알았는데 인증 요청과 확인이 하나의 뷰에서 이루어지고 UI만 변해서 [ 이용 약관 (Step1) -> 이메일 인증 (Step2) -> 비밀번호 설정 (Step3) -> 환영 인사 (Step4) -> 블로그 주소 설정 (Step5) ]로 구성 예정
지난 번 만들었던 SignUpView는 현재 앱에서 연결이 끊긴 상태이며 추후 Step4를 구현할 때 다시 연결 예정, PR에서는 Step6로 언급했었으나 과정을 착각한 연유로 Step5가 될 예정

참고 영상

https://github.com/user-attachments/assets/12e57107-8609-462e-a2d8-eeb94025304c

