### PR TITLE
Feature/refactor-notification-type-sheet

### DIFF
--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct MainTabView: View {
     
-    @State private var selectedTab: TabType = .home
     @State var mainTabViewModel: MainTabViewModel = MainTabViewModel()
     @State var notificationViewModel: NotificationViewModel = NotificationViewModel()
     

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -10,61 +10,71 @@ import SwiftUI
 struct MainTabView: View {
     
     @State private var selectedTab: TabType = .home
+    @State var mainTabViewModel: MainTabViewModel = MainTabViewModel()
+    @State var notificationViewModel: NotificationViewModel = NotificationViewModel()
     
     var body: some View {
         
-        //TODO: 각 tabItem 이미지
-        TabView(selection: $selectedTab) {
-            Group {
-                NavigationStack {
-                    // homeView
+        ZStack {
+            //TODO: 각 tabItem 이미지
+            TabView(selection: $mainTabViewModel.selectedTab) {
+                Group {
+                    NavigationStack {
+                        // homeView
+                    }
+                    .tabItem {
+                        Text("홈")
+                    }
+                    .tag(TabType.home)
+                    
+                    
+                    NavigationStack {
+                        FeedView()
+                    }
+                    .tabItem {
+                        Text("피드")
+                    }
+                    .tag(TabType.feed)
+                    
+                    
+                    NavigationStack {
+                        // writeView
+                    }
+                    .tabItem {
+                        Text("글쓰기")
+                    }
+                    .tag(TabType.write)
+                    
+                    
+                    NavigationStack {
+                        NotificationView(viewModel: notificationViewModel, mainTabViewModel: mainTabViewModel)
+                    }
+                    .tabItem {
+                        Text("알림")
+                    }
+                    .tag(TabType.notification)
+                    
+                    
+                    NavigationStack {
+                        // statView
+                    }
+                    .tabItem {
+                        Text("stat")
+                    }
+                    .tag(TabType.stat)
                 }
-                .tabItem {
-                    Text("홈")
-                }
-                .tag(TabType.home)
-                
-                
-                NavigationStack {
-                    FeedView()
-                }
-                .tabItem {
-                    Text("피드")
-                }
-                .tag(TabType.feed)
-                
-                
-                NavigationStack {
-                    // writeView
-                }
-                .tabItem {
-                    Text("글쓰기")
-                }
-                .tag(TabType.write)
-                
-                
-                NavigationStack {
-                    NotificationView()
-                }
-                .tabItem {
-                    Text("알림")
-                }
-                .tag(TabType.notification)
-                
-                
-                NavigationStack {
-                    // statView
-                }
-                .tabItem {
-                    Text("stat")
-                }
-                .tag(TabType.stat)
+                .toolbarBackground(.white, for: .tabBar)
+                .toolbarBackground(.visible, for: .tabBar)
+                .toolbarBackground(Color.white, for: .navigationBar)
             }
-            .toolbarBackground(.white, for: .tabBar)
-            .toolbarBackground(.visible, for: .tabBar)
-            .toolbarBackground(Color.white, for: .navigationBar)
+            .tint(.black)
+            
+            
+            //MARK: NotificationTypeSheet
+            NotificationTypeSheet(viewModel: notificationViewModel, mainTabViewModel: mainTabViewModel)
+            
+
         }
-        .tint(.black)
     }
 }
 

--- a/Wastory/Wastory/View/NotificationView/NotificationTypeSheet.swift
+++ b/Wastory/Wastory/View/NotificationView/NotificationTypeSheet.swift
@@ -8,52 +8,85 @@
 import SwiftUI
 
 struct NotificationTypeSheet: View {
-    @Binding var viewModel: NotificationViewModel
+    @Bindable var viewModel: NotificationViewModel
+    @Bindable var mainTabViewModel: MainTabViewModel
     
     var body: some View {
         ZStack {
-            VStack(spacing: 0) {
+            //MARK: Background Dimming
+            (mainTabViewModel.isNotificationTypeSheetPresent ? Color.sheetOuterBackgroundColor : Color.clear)
+                .frame(maxHeight: .infinity)
+                .frame(maxWidth: .infinity)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    mainTabViewModel.toggleIsNotificationTypeSheetPresent()
+                }
+            
+            //MARK: NotificationTypeSheet List
+            VStack {
                 Spacer()
-                    .frame(height: 15)
-                
-                ForEach(viewModel.notificationTypes.indices, id: \.self) { index in
-                    let type = viewModel.notificationTypes[index]
+                if mainTabViewModel.isNotificationTypeSheetPresent {
+                    let typeSheetTopSpace = viewModel.typeSheetTopSpace
+                    let typeSheetRowHeight = viewModel.typeSheetRowHeight
+                    let typeSheetBottomSpace = viewModel.typeSheetBottomSpace
+                    let typeSheetHeight = typeSheetTopSpace + typeSheetBottomSpace + CGFloat(viewModel.notificationTypes.count) * typeSheetRowHeight
                     
-                    Button(action: {
-                        viewModel.setNotificationType(to: type)
-                        viewModel.toggleIsTypeSheetPresent()
-                    }) {
-                        HStack(spacing: 0) {
-                            Text("\(type)")
-                                .font(.system(size: 17, weight: viewModel.isCurrentType(is: type) ? .semibold : .light))
-                                .padding()
+                    ZStack {
+                        VStack(spacing: 0) {
+                            Spacer()
+                                .frame(height: typeSheetTopSpace)
                             
+                            ForEach(viewModel.notificationTypes.indices, id: \.self) { index in
+                                let type = viewModel.notificationTypes[index]
+                                
+                                NotificationTypeButton(for: type, isLast: index == viewModel.notificationTypes.count - 1, rowHeight: typeSheetRowHeight)
+                            }
                             
                             Spacer()
-                            
-                            Image(systemName: "checkmark.circle.fill")
-                                .tint(viewModel.isCurrentType(is: type) ? Color.primaryLabelColor : Color.clear)
-                                .font(.system(size: 20, weight: .regular))
-                                .padding(.trailing, 15)
+                                .frame(height: typeSheetBottomSpace)
                         }
+                        .frame(height: typeSheetHeight)
+                        .background(Color.white)
+                        .cornerRadius(20)
+                        
                     }
-                    .frame(height: 60)
-                    .frame(maxWidth: .infinity)
+                    .background(Color.clear)
+                    .transition(.move(edge: .bottom)) // 아래에서 올라오는 애니메이션
+                    .animation(.easeInOut, value: mainTabViewModel.isNotificationTypeSheetPresent)
                     
-                    if !viewModel.isLastType(index: index) {
-                        Divider()
-                            .foregroundStyle(Color.secondaryLabelColor)
-                    }
                 }
-                
-                Spacer()
-                    .frame(height: 15)
             }
-            .frame(height: 60 * 6 + 15 * 2)
-            .background(Color.white)
-            .cornerRadius(20)
             
         }
-        .background(Color.sheetOuterBackgroundColor)
+        .ignoresSafeArea()
+    }
+    
+    //MARK: NotificationTypeSheet Row(Button)
+    @ViewBuilder func NotificationTypeButton(for type: String, isLast: Bool, rowHeight: CGFloat) -> some View {
+        Button(action: {
+            viewModel.setNotificationType(to: type)
+            mainTabViewModel.toggleIsNotificationTypeSheetPresent()
+        }) {
+            HStack(spacing: 0) {
+                Text("\(type)")
+                    .font(.system(size: 17, weight: viewModel.isCurrentType(is: type) ? .semibold : .light))
+                    .foregroundStyle(Color.primaryLabelColor)
+                    .padding()
+                
+                Spacer()
+                
+                Image(systemName: "checkmark.circle.fill")
+                    .tint(viewModel.isCurrentType(is: type) ? Color.primaryLabelColor : Color.clear)
+                    .font(.system(size: 20, weight: .regular))
+                    .padding(.trailing, 15)
+            }
+        }
+        .frame(height: rowHeight)
+        .frame(maxWidth: .infinity)
+        
+        if !isLast {
+            Divider()
+                .foregroundStyle(Color.secondaryLabelColor)
+        }
     }
 }

--- a/Wastory/Wastory/View/NotificationView/NotificationView.swift
+++ b/Wastory/Wastory/View/NotificationView/NotificationView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct NotificationView: View {
-    @State private var viewModel = NotificationViewModel()
+    @Bindable var viewModel: NotificationViewModel
+    @Bindable var mainTabViewModel: MainTabViewModel
     
     //임시 데이터 배열
     var items: [String] = ["아이템 1", "아이템 2", "아이템 3", "아이템 4", "아이템 5"]
@@ -38,7 +39,7 @@ struct NotificationView: View {
                         
                         // 알림 종류 선택 button
                         Button(action: {
-                            viewModel.toggleIsTypeSheetPresent()
+                            mainTabViewModel.toggleIsNotificationTypeSheetPresent()
                         }) {
                             HStack(spacing: 0) {
                                 Text("\(viewModel.getNotificationType())  ")
@@ -62,21 +63,21 @@ struct NotificationView: View {
                     }
                 }
                 
-                (viewModel.isTypeSheetPresent ? Color.sheetOuterBackgroundColor : Color.clear)
-                    .frame(maxHeight: .infinity)
-                    .frame(maxWidth: .infinity)
-                    .ignoresSafeArea()
-                    .onTapGesture {
-                        viewModel.toggleIsTypeSheetPresent()
-                    }
+//                (mainTabViewModel.isNotificationTypeSheetPresent ? Color.sheetOuterBackgroundColor : Color.clear)
+//                    .frame(maxHeight: .infinity)
+//                    .frame(maxWidth: .infinity)
+//                    .ignoresSafeArea()
+//                    .onTapGesture {
+//                        mainTabViewModel.toggleIsNotificationTypeSheetPresent()
+//                    }
                 
             }
             
-            if viewModel.isTypeSheetPresent {
-                NotificationTypeSheet(viewModel: $viewModel)
-                    .transition(.move(edge: .bottom)) // 아래에서 올라오는 애니메이션
-                    .animation(.easeInOut, value: viewModel.isTypeSheetPresent)
-            }
+//            if mainTabViewModel.isNotificationTypeSheetPresent {
+//                NotificationTypeSheet(viewModel: viewModel)
+//                    .transition(.move(edge: .bottom)) // 아래에서 올라오는 애니메이션
+//                    .animation(.easeInOut, value: mainTabViewModel.isNotificationTypeSheetPresent)
+//            }
         }
         // MARK: NavBar
         // TODO: rightTabButton - 검색버튼과 본인계정버튼은 4개의 TabView에 공통 적용이므로 추후 제작

--- a/Wastory/Wastory/View/NotificationView/NotificationView.swift
+++ b/Wastory/Wastory/View/NotificationView/NotificationView.swift
@@ -62,22 +62,7 @@ struct NotificationView: View {
                         }
                     }
                 }
-                
-//                (mainTabViewModel.isNotificationTypeSheetPresent ? Color.sheetOuterBackgroundColor : Color.clear)
-//                    .frame(maxHeight: .infinity)
-//                    .frame(maxWidth: .infinity)
-//                    .ignoresSafeArea()
-//                    .onTapGesture {
-//                        mainTabViewModel.toggleIsNotificationTypeSheetPresent()
-//                    }
-                
-            }
             
-//            if mainTabViewModel.isNotificationTypeSheetPresent {
-//                NotificationTypeSheet(viewModel: viewModel)
-//                    .transition(.move(edge: .bottom)) // 아래에서 올라오는 애니메이션
-//                    .animation(.easeInOut, value: mainTabViewModel.isNotificationTypeSheetPresent)
-//            }
         }
         // MARK: NavBar
         // TODO: rightTabButton - 검색버튼과 본인계정버튼은 4개의 TabView에 공통 적용이므로 추후 제작

--- a/Wastory/Wastory/View/NotificationView/NotificationView.swift
+++ b/Wastory/Wastory/View/NotificationView/NotificationView.swift
@@ -62,7 +62,7 @@ struct NotificationView: View {
                         }
                     }
                 }
-            
+            }
         }
         // MARK: NavBar
         // TODO: rightTabButton - 검색버튼과 본인계정버튼은 4개의 TabView에 공통 적용이므로 추후 제작

--- a/Wastory/Wastory/ViewModel/MainTabViewModel.swift
+++ b/Wastory/Wastory/ViewModel/MainTabViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  MainTabViewModel.swift
+//  Wastory
+//
+//  Created by 중워니 on 1/1/25.
+//
+
+import SwiftUI
+import Observation
+
+@Observable final class MainTabViewModel {
+    var selectedTab: TabType = .home
+    
+    var isNotificationTypeSheetPresent: Bool = false
+    
+    
+    //MARK: isNotificationTypeSheetPresent
+    func toggleIsNotificationTypeSheetPresent() {
+        withAnimation(.easeInOut) {
+            isNotificationTypeSheetPresent.toggle()
+        }
+    }
+    
+    func getIsNotificationTypeSheetPresent() -> Bool {
+        isNotificationTypeSheetPresent
+    }
+    
+}

--- a/Wastory/Wastory/ViewModel/NotificationViewModel/NotificationViewModel.swift
+++ b/Wastory/Wastory/ViewModel/NotificationViewModel/NotificationViewModel.swift
@@ -18,9 +18,9 @@ import Observation
     
     
     //NotificationTypeSheet Layout
-    var typeSheetTopSpace: CGFloat = 15
-    var typeSheetRowHeight: CGFloat = 60
-    var typeSheetBottomSpace: CGFloat = 30
+    let typeSheetTopSpace: CGFloat = 15
+    let typeSheetRowHeight: CGFloat = 60
+    let typeSheetBottomSpace: CGFloat = 30
     
     
     //MARK: NotificationType

--- a/Wastory/Wastory/ViewModel/NotificationViewModel/NotificationViewModel.swift
+++ b/Wastory/Wastory/ViewModel/NotificationViewModel/NotificationViewModel.swift
@@ -12,21 +12,15 @@ import Observation
     let notificationTypes = ["전체 알림", "새글 알림", "구독 알림", "댓글 알림", "방명록 알림", "챌린지 알림"]
     var notificationType: String = "전체 알림"
     
-    var isTypeSheetPresent = false
     var typeSheetHeight: CGFloat = 0
     
     private var isNavTitleHidden = false
     
-    //MARK: isTypeSheetPresent
-    func toggleIsTypeSheetPresent() {
-        withAnimation(.easeInOut) {
-            isTypeSheetPresent.toggle()
-        }
-    }
     
-    func getIsTypeSheetPresent() -> Bool {
-        isTypeSheetPresent
-    }
+    //NotificationTypeSheet Layout
+    var typeSheetTopSpace: CGFloat = 15
+    var typeSheetRowHeight: CGFloat = 60
+    var typeSheetBottomSpace: CGFloat = 30
     
     
     //MARK: NotificationType


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[O] 기능 추가
 -[] 기능 삭제 
-[] 버그 수정 
-[O] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
 feature/refactor-notification-type-sheet -> main

### 변경 사항 

NotificationTypeSheet가 MainTabBar 위로 올라오도록 수정하였습니다.

#### MainTabViewModel 생성
- selectedTab 관리
- tabView 위로 올라오는 뷰들 (NotificationTypeSheet, 추후에 글쓰기 뷰)의 표시 여부 관리
- MainTabView에 있는 ZStack에 앞서 설명한 뷰들을 넣어야 하기에 필요

#### MainTabView변경사항
- NotificationTypeSheet가 NotificationViewModel을 필요로 하기에 MainTabView에서 NotificationViewModel 생성 -> Notification 관련 View들에 주입
- MainTabViewModel에 isNotificationTypeSheetPresent가 있기에 이를 Notification 관련 View들에서 관리하기 위헤 MainTabViewModel을 주입

#### NotificationTypeSheet
- ViewModel을 View에서 복잡하게 이용해서 컴파일러 오류가 나길래 ViewBuilder를 이용해 각 행을 뷰를 리턴하는 함수로 구현
- 기존에 NotificationView에 있던 background Dimming 기능을 TypeSheet로 이전
- 기존에 NotificationView에 있던 isNotificationTypeSheetPresent 여부도 TypeSheet로 이전

#### NotificationViewModel
- typeSheet의 각 행의 높이와 위 아래 여백을 이제 디자인 수정 편의성을 고려하여 View에서 관리하지 않고 ViewModel에서 관리하게 함
- 기존의 isTypeSheetPresent는 MainTabViewModel에서 관리

### 추후 보완 사항
- 새글 알림은 임의의 블로그 구독을 통해 확인할 수 있었으나 구독, 댓글, 방명록, 챌린지 알림은 어떤 UI를 가지고 있고, Cell 클릭 시 어떤 상호작용을 하는지 아직 확인하지 못함. 추후 서로의 계정으로 확인을 통해 정리할 필요가 있어보입니다.
- 새로고침 기능 (서버와 연결 후 제작)
- 알림 종류를 고르는 기능은 완성 되었으나 그에 따라 알림 표시 유무를 관리하는 기능은 아직 없음. 추후 API와 연결 후 어떤 데이터 구조를 가지게 될 지 정한 뒤에 만드는 것이 나아보입니다.

- 글쓰기 View도 이와 같은 방법으로 구현하면 될 것 같습니다.


참고영상 :

https://github.com/user-attachments/assets/4d013aa1-be67-464b-b803-a83265456294


