### PR TITLE
Feat: Implement SignUp View Step2 - Email View

### DIFF
--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -86,7 +86,7 @@ struct SignUpStep2EmailView: View {
                         .background(.white)
                         .overlay(
                             RoundedRectangle(cornerRadius: 40)
-                                .stroke(Color.codeRequestButtonColor, lineWidth: 1)
+                                .stroke(Color.codeRequestButtonGray, lineWidth: 1)
                         )
                         .padding(.trailing, 20)
                     }
@@ -115,7 +115,7 @@ struct SignUpStep2EmailView: View {
                         .foregroundStyle(.black)
                         .padding(.vertical, 16)
                         .frame(maxWidth: .infinity, idealHeight: 51)
-                        .background(viewModel.isCodeEntered() ? Color.kakaoYellow : Color.disabledNextButtonColor)
+                        .background(viewModel.isCodeEntered() ? Color.kakaoYellow : Color.disabledNextButtonGray)
                         .cornerRadius(6)
                 }
                 .padding(.horizontal, 20)

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -202,7 +202,7 @@ struct SignUpStep2CautionText: View {
 extension Color {
     static let codeRequestButtonGray: Color = .init(red: 208 / 255, green: 208 / 255, blue: 208 / 255)  // 인증 요청 버튼 테두리 색상
     static let disabledNextButtonGray: Color = .init(red: 240 / 255, green: 240 / 255, blue: 240 / 255)  // 다음 버튼 이용 불가능 색상
-    static let emailCautionTextGray: Color = .init(red: 153 / 255, green: 153 / 255, blue: 153 / 255)  // 다음 버튼 이용 불가능 색상
+    static let emailCautionTextGray: Color = .init(red: 153 / 255, green: 153 / 255, blue: 153 / 255)  // 이메일 입력 주의사항 색상
     static let emptyEmailWarnRed: Color = .init(red: 208 / 255, green: 104 / 255, blue: 79 / 255)  // 이메일 미입력 경고 색상
 }
 

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -72,6 +72,7 @@ struct SignUpStep2EmailView: View {
                     if viewModel.isCodeRequired() {
                         TextField("", text: $viewModel.code, prompt: Text("인증번호 8자 입력")
                             .foregroundStyle(Color.promptLabelColor))
+                        .keyboardType(.numberPad)
                         .padding(.vertical, 5)
                         .padding(.horizontal, 20)
                         .autocapitalization(.none)

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -182,7 +182,7 @@ struct SignUpStep2EmailView: View {
                         .frame(height: 24)
                 }
                 
-                NavigationLink(destination: EmptyView()) {
+                NavigationLink(destination: SignUpStep3PasswordView()) {
                     Text("다음")
                         .font(.system(size: 16, weight: .regular))
                         .foregroundStyle(.black)
@@ -193,6 +193,11 @@ struct SignUpStep2EmailView: View {
                 }
                 .padding(.horizontal, 20)
                 .disabled(viewModel.isCodeEntered() == false)
+                .simultaneousGesture(
+                    TapGesture().onEnded {
+                        UserInfoRepository.shared.setUserID(userID: viewModel.email)
+                    }
+                )
                 
                 Spacer()
             }

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -145,11 +145,11 @@ struct SignUpStep2EmailView: View {
                     .frame(height: 1)
                     .padding(.horizontal, 20)
                 
-                if viewModel.isEmptyEmailRequested() {
+                if viewModel.isEmptyEmailRequested() || viewModel.isInvalidEmailRequested() {
                     Spacer()
                         .frame(height: 5)
                     HStack {
-                        Text("와스토리 계정 이메일을 입력해 주세요.")
+                        Text(viewModel.isEmptyEmailRequested() ? "와스토리 계정 이메일을 입력해 주세요." : "와스토리 계정 이메일 형식이 올바르지 않습니다.")
                             .font(.system(size: 11, weight: .light))
                             .foregroundStyle(Color.emptyEmailWarnRed)
                         Spacer()

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -75,6 +75,11 @@ struct SignUpStep2EmailView: View {
                         .padding(.vertical, 5)
                         .padding(.horizontal, 20)
                         .autocapitalization(.none)
+                        .onChange(of: viewModel.code) { newValue, oldValue in
+                            if newValue.count >= 8 {
+                                viewModel.code = String(viewModel.code.prefix(8))
+                            }
+                        }
                         
                         HStack {
                             Spacer()

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -10,201 +10,285 @@ import SwiftUI
 struct SignUpStep2EmailView: View {
     @State private var viewModel = SignUpStep2ViewModel()
     @State private var isNavigationActive = false
+    @State private var showRerequestEmailBox = false
     
     var body: some View {
         NavigationStack {
-            VStack {
-                ZStack {
+            ZStack {
+                VStack {
+                    ZStack {
+                        HStack {
+                            Rectangle()
+                                .foregroundStyle(Color.progressBarBackgroundColor)
+                                .frame(width: 60, height: 5)
+                                .cornerRadius(12)
+                                .padding(.leading, 20)
+                            Spacer()
+                        }
+                        HStack {
+                            Rectangle()
+                                .foregroundStyle(Color.progressBarProgressColor)
+                                .frame(width: 40, height: 5)
+                                .cornerRadius(12)
+                                .padding(.leading, 20)
+                            Spacer()
+                        }
+                    }
+                    .padding(.top, 20)
+                    
                     HStack {
-                        Rectangle()
-                            .foregroundStyle(Color.progressBarBackgroundColor)
-                            .frame(width: 60, height: 5)
-                            .cornerRadius(12)
-                            .padding(.leading, 20)
+                        Text(viewModel.isCodeRequired() ? "이메일로 발송된" : "와스토리 계정으로 사용할")
+                            .font(.system(size: 18, weight: .regular))
+                            .padding(.horizontal, 20)
                         Spacer()
                     }
-                    HStack {
-                        Rectangle()
-                            .foregroundStyle(Color.progressBarProgressColor)
-                            .frame(width: 40, height: 5)
-                            .cornerRadius(12)
-                            .padding(.leading, 20)
-                        Spacer()
-                    }
-                }
-                .padding(.top, 20)
-                
-                HStack {
-                    Text(viewModel.isCodeRequired() ? "이메일로 발송된" : "와스토리 계정으로 사용할")
-                        .font(.system(size: 18, weight: .regular))
-                        .padding(.horizontal, 20)
-                    Spacer()
-                }
-                .padding(.top, 24)
-                Spacer()
-                    .frame(height: 5)
-                HStack {
-                    Text(viewModel.isCodeRequired() ? "인증번호를 입력해 주세요." : "이메일을 입력해 주세요.")
-                        .font(.system(size: 18, weight: .regular))
-                        .padding(.horizontal, 20)
-                    Spacer()
-                }
-                
-                Spacer()
-                    .frame(height: 30)
-                
-                if viewModel.isCodeRequired() {
-                    HStack {
-                        Text(viewModel.email)
-                            .foregroundStyle(Color.promptLabelColor)
-                            .padding(.vertical, 5)
-                        Spacer()
-                    }
-                    .padding(.horizontal, 20)
+                    .padding(.top, 24)
                     Spacer()
                         .frame(height: 5)
+                    HStack {
+                        Text(viewModel.isCodeRequired() ? "인증번호를 입력해 주세요." : "이메일을 입력해 주세요.")
+                            .font(.system(size: 18, weight: .regular))
+                            .padding(.horizontal, 20)
+                        Spacer()
+                    }
+                    
+                    Spacer()
+                        .frame(height: 30)
+                    
+                    if viewModel.isCodeRequired() {
+                        HStack {
+                            Text(viewModel.email)
+                                .foregroundStyle(Color.promptLabelColor)
+                                .padding(.vertical, 5)
+                            Spacer()
+                        }
+                        .padding(.horizontal, 20)
+                        Spacer()
+                            .frame(height: 5)
+                        Rectangle()
+                            .foregroundStyle(Color.promptLabelColor)
+                            .frame(height: 1)
+                            .padding(.horizontal, 20)
+                    }
+                    
+                    ZStack {
+                        if viewModel.isCodeRequired() {
+                            TextField("", text: $viewModel.code, prompt: Text("인증번호 8자 입력")
+                                .foregroundStyle(Color.promptLabelColor))
+                            .keyboardType(.numberPad)
+                            .padding(.vertical, 5)
+                            .padding(.horizontal, 20)
+                            .autocapitalization(.none)
+                            .onChange(of: viewModel.code) { newValue, oldValue in
+                                if oldValue.count >= 8 {
+                                    viewModel.code = String(viewModel.code.prefix(8))
+                                }
+                                viewModel.checkCodeValidty(oldValue)
+                            }
+                            
+                            HStack {
+                                Spacer()
+                                Button {
+                                    viewModel.clearCodeTextField()
+                                } label: {
+                                    Image(systemName: "multiply.circle.fill")
+                                        .font(.system(size: 15))
+                                        .foregroundStyle(Color.promptLabelColor)
+                                }
+                                .frame(width: 10, height: 10)
+                                .padding(.trailing, 24)
+                                .disabled(viewModel.isClearCodeButtonInactive())
+                                .opacity(viewModel.isClearCodeButtonInactive() ? 0 : 1)
+                            }
+                        }
+                        else {
+                            TextField("", text: $viewModel.email, prompt: Text("이메일 입력")
+                                .foregroundStyle(Color.promptLabelColor))
+                            .padding(.vertical, 5)
+                            .padding(.horizontal, 20)
+                            .autocapitalization(.none)
+                            
+                            HStack {
+                                Spacer()
+                                Button {
+                                    viewModel.clearEmailTextField()
+                                } label: {
+                                    Image(systemName: "multiply.circle.fill")
+                                        .font(.system(size: 15))
+                                        .foregroundStyle(Color.promptLabelColor)
+                                }
+                                .frame(width: 10, height: 10)
+                                .padding(.trailing, 10)
+                                .disabled(viewModel.isClearEmailButtonInactive())
+                                .opacity(viewModel.isClearEmailButtonInactive() ? 0 : 1)
+                                
+                                Button {
+                                    viewModel.requestCode()
+                                } label: {
+                                    Text("인증요청")
+                                        .font(.system(size: 14, weight: .regular))
+                                        .foregroundStyle(.black)
+                                        .padding(.vertical, 7)
+                                        .padding(.horizontal, 14)
+                                }
+                                .background(.white)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 40)
+                                        .stroke(Color.codeRequestButtonGray, lineWidth: 1)
+                                )
+                                .padding(.trailing, 20)
+                            }
+                        }
+                    }
+                    
+                    Spacer()
+                        .frame(height: 5)
+                    
                     Rectangle()
-                        .foregroundStyle(Color.promptLabelColor)
+                        .foregroundStyle(viewModel.isEmptyEmailRequested() || viewModel.isInvalidEmailRequested() || viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered() ? Color.emptyEmailWarnRed : .black)
                         .frame(height: 1)
                         .padding(.horizontal, 20)
-                }
-                
-                ZStack {
-                    if viewModel.isCodeRequired() {
-                        TextField("", text: $viewModel.code, prompt: Text("인증번호 8자 입력")
-                            .foregroundStyle(Color.promptLabelColor))
-                        .keyboardType(.numberPad)
-                        .padding(.vertical, 5)
-                        .padding(.horizontal, 20)
-                        .autocapitalization(.none)
-                        .onChange(of: viewModel.code) { newValue, oldValue in
-                            if oldValue.count >= 8 {
-                                viewModel.code = String(viewModel.code.prefix(8))
-                            }
-                            viewModel.checkCodeValidty(oldValue)
-                        }
-                        
+                    
+                    if viewModel.isEmptyEmailRequested() || viewModel.isInvalidEmailRequested() || viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered() {
+                        Spacer()
+                            .frame(height: 5)
                         HStack {
+                            Text(viewModel.isEmptyEmailRequested() ? "와스토리 계정 이메일을 입력해 주세요." : viewModel.isInvalidEmailRequested() ?  "와스토리 계정 이메일 형식이 올바르지 않습니다." : viewModel.isEmptyCodeEntered() ? "이메일로 발송된 인증번호를 입력해 주세요." : "인증번호 형식이 올바르지 않습니다.")
+                                .font(.system(size: 11, weight: .light))
+                                .foregroundStyle(Color.emptyEmailWarnRed)
                             Spacer()
-                            Button {
-                                viewModel.clearCodeTextField()
-                            } label: {
-                                Image(systemName: "multiply.circle.fill")
-                                    .font(.system(size: 15))
-                                    .foregroundStyle(Color.promptLabelColor)
-                            }
-                            .frame(width: 10, height: 10)
-                            .padding(.trailing, 24)
-                            .disabled(viewModel.isClearCodeButtonInactive())
-                            .opacity(viewModel.isClearCodeButtonInactive() ? 0 : 1)
                         }
+                        .padding(.horizontal, 20)
+                    }
+                    
+                    Spacer()
+                        .frame(height: 24)
+                    
+                    if viewModel.isCodeRequired() == false {
+                        SignUpStep2CautionText(text: "입력한 이메일로 인증번호가 발송됩니다.")
+                        SignUpStep2CautionText(text: "인증메일을 받을 수 있도록 자주 쓰는 이메일을 입력해 주세요.")
+                        Spacer()
+                            .frame(height: 24)
                     }
                     else {
-                        TextField("", text: $viewModel.email, prompt: Text("이메일 입력")
-                            .foregroundStyle(Color.promptLabelColor))
-                        .padding(.vertical, 5)
-                        .padding(.horizontal, 20)
-                        .autocapitalization(.none)
-                        
-                        HStack {
-                            Spacer()
-                            Button {
-                                viewModel.clearEmailTextField()
-                            } label: {
-                                Image(systemName: "multiply.circle.fill")
-                                    .font(.system(size: 15))
-                                    .foregroundStyle(Color.promptLabelColor)
-                            }
-                            .frame(width: 10, height: 10)
-                            .padding(.trailing, 10)
-                            .disabled(viewModel.isClearEmailButtonInactive())
-                            .opacity(viewModel.isClearEmailButtonInactive() ? 0 : 1)
-                            
-                            Button {
-                                viewModel.requestCode()
-                            } label: {
-                                Text("인증요청")
-                                    .font(.system(size: 14, weight: .regular))
+                        Button {
+                            showRerequestEmailBox = true
+                        } label: {
+                            HStack {
+                                Text("인증메일을 받지 못하셨나요?")
+                                    .font(.system(size: 11, weight: .regular))
                                     .foregroundStyle(.black)
-                                    .padding(.vertical, 7)
-                                    .padding(.horizontal, 14)
+                                    .underline()
+                                Spacer()
                             }
-                            .background(.white)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 40)
-                                    .stroke(Color.codeRequestButtonGray, lineWidth: 1)
-                            )
-                            .padding(.trailing, 20)
+                            .padding(.horizontal, 20)
                         }
-                    }
-                }
-
-                Spacer()
-                    .frame(height: 5)
-                
-                Rectangle()
-                    .foregroundStyle(viewModel.isEmptyEmailRequested() || viewModel.isInvalidEmailRequested() || viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered() ? Color.emptyEmailWarnRed : .black)
-                    .frame(height: 1)
-                    .padding(.horizontal, 20)
-                
-                if viewModel.isEmptyEmailRequested() || viewModel.isInvalidEmailRequested() || viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered() {
-                    Spacer()
-                        .frame(height: 5)
-                    HStack {
-                        Text(viewModel.isEmptyEmailRequested() ? "와스토리 계정 이메일을 입력해 주세요." : viewModel.isInvalidEmailRequested() ?  "와스토리 계정 이메일 형식이 올바르지 않습니다." : viewModel.isEmptyCodeEntered() ? "이메일로 발송된 인증번호를 입력해 주세요." : "인증번호 형식이 올바르지 않습니다.")
-                            .font(.system(size: 11, weight: .light))
-                            .foregroundStyle(Color.emptyEmailWarnRed)
+                        .buttonStyle(PlainButtonStyle())
                         Spacer()
+                            .frame(height: 24)
+                    }
+                    
+                    Button {
+                        if viewModel.isVerificationSuccessful() {
+                            isNavigationActive = true
+                            UserInfoRepository.shared.setUserID(userID: viewModel.email)    // UserID (email) 결정
+                        }
+                    } label: {
+                        Text("다음")
+                            .font(.system(size: 16, weight: .regular))
+                            .foregroundStyle(.black)
+                            .padding(.vertical, 16)
+                            .frame(maxWidth: .infinity, idealHeight: 51)
+                            .background(viewModel.code.isEmpty || viewModel.isInvalidCodeEntered() ? Color.disabledNextButtonGray : Color.kakaoYellow)
+                            .cornerRadius(6)
                     }
                     .padding(.horizontal, 20)
-                }
-                
-                Spacer()
-                    .frame(height: 24)
-                
-                if viewModel.isCodeRequired() == false {
-                    SignUpStep2CautionText(text: "입력한 이메일로 인증번호가 발송됩니다.")
-                    SignUpStep2CautionText(text: "인증메일을 받을 수 있도록 자주 쓰는 이메일을 입력해 주세요.")
+                    .navigationDestination(isPresented: $isNavigationActive) {
+                        SignUpStep3PasswordView()
+                    }
+                    
                     Spacer()
-                        .frame(height: 24)
                 }
-                else {
-                    Button {
-                    } label: {
+                
+                if showRerequestEmailBox {
+                    Color.black.opacity(0.5)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            // 편의 기능: 버튼 대신 배경을 터치하여도 박스 닫힘
+                            showRerequestEmailBox = false
+                        }
+                    
+                    Rectangle()
+                        .foregroundStyle(.white)
+                        .frame(height: 300)
+                        .cornerRadius(12)
+                        .padding(.horizontal, 20)
+                    
+                    VStack(spacing: 12) {
                         HStack {
                             Text("인증메일을 받지 못하셨나요?")
-                                .font(.system(size: 11, weight: .regular))
-                                .foregroundStyle(.black)
-                                .underline()
+                                .font(.system(size: 15, weight: .semibold))
+                                .padding(.horizontal, 40)
                             Spacer()
                         }
-                        .padding(.horizontal, 20)
+                        HStack {
+                            Text("이메일이 정확한지 확인해 주세요.")
+                                .font(.system(size: 14))
+                                .foregroundStyle(Color.emailCautionTextGray)
+                                .padding(.horizontal, 40)
+                            Spacer()
+                        }
+                        HStack {
+                            Text("메일 서비스에 따라 인증번호 발송이 늦어질 수 있습니다.")
+                                .font(.system(size: 14))
+                                .foregroundStyle(Color.emailCautionTextGray)
+                                .padding(.horizontal, 40)
+                            Spacer()
+                        }
+                        
+                        Button {
+                            viewModel.requestEmailReentry()
+                            showRerequestEmailBox = false
+                        } label: {
+                            HStack {
+                                Text("다른 이메일로 인증")
+                                    .font(.system(size: 12, weight: .regular))
+                                    .foregroundStyle(.black)
+                                    .underline()
+                                Spacer()
+                            }
+                            .padding(.horizontal, 40)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        Spacer()
+                            .frame(height: 2)
+                        
+                        Button {
+                            showRerequestEmailBox = false
+                        } label: {
+                            Text("인증번호 재발송")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(.black)
+                                .padding(.vertical, 16)
+                                .frame(maxWidth: .infinity, idealHeight: 45)
+                                .background(Color.kakaoYellow)
+                                .cornerRadius(6)
+                        }
+                        .padding(.horizontal, 40)
+                        Button {
+                            showRerequestEmailBox = false
+                        } label: {
+                            Text("확인")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(.black)
+                                .padding(.vertical, 16)
+                                .frame(maxWidth: .infinity, idealHeight: 45)
+                                .background(Color.disabledNextButtonGray)
+                                .cornerRadius(6)
+                        }
+                        .padding(.horizontal, 40)
                     }
-                    .buttonStyle(PlainButtonStyle())
-                    Spacer()
-                        .frame(height: 24)
                 }
-                
-                Button {
-                    if viewModel.isVerificationSuccessful() {
-                        isNavigationActive = true
-                        UserInfoRepository.shared.setUserID(userID: viewModel.email)
-                    }
-                } label: {
-                    Text("다음")
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundStyle(.black)
-                        .padding(.vertical, 16)
-                        .frame(maxWidth: .infinity, idealHeight: 51)
-                        .background(viewModel.code.isEmpty || viewModel.isInvalidCodeEntered() ? Color.disabledNextButtonGray : Color.kakaoYellow)
-                        .cornerRadius(6)
-                }
-                .padding(.horizontal, 20)
-                .navigationDestination(isPresented: $isNavigationActive) {
-                    SignUpStep3PasswordView()
-                }
-                
-                Spacer()
             }
         }
     }

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -11,6 +11,143 @@ struct SignUpStep2EmailView: View {
     @State private var viewModel = SignUpStep2ViewModel()
     
     var body: some View {
-        Text("이메일 인증 뷰")
+        NavigationStack {
+            VStack {
+                ZStack {
+                    HStack {
+                        Rectangle()
+                            .foregroundStyle(Color.progressBarBackgroundColor)
+                            .frame(width: 60, height: 5)
+                            .cornerRadius(12)
+                            .padding(.leading, 20)
+                        Spacer()
+                    }
+                    HStack {
+                        Rectangle()
+                            .foregroundStyle(Color.progressBarProgressColor)
+                            .frame(width: 40, height: 5)
+                            .cornerRadius(12)
+                            .padding(.leading, 20)
+                        Spacer()
+                    }
+                }
+                .padding(.top, 20)
+                
+                HStack {
+                    Text("와스토리 계정으로 사용할")
+                        .font(.system(size: 18, weight: .regular))
+                        .padding(.horizontal, 20)
+                    Spacer()
+                }
+                .padding(.top, 24)
+                Spacer()
+                    .frame(height: 5)
+                HStack {
+                    Text("이메일을 입력해 주세요.")
+                        .font(.system(size: 18, weight: .regular))
+                        .padding(.horizontal, 20)
+                    Spacer()
+                }
+                
+                Spacer()
+                    .frame(height: 30)
+                
+                ZStack {
+                    TextField("", text: $viewModel.email, prompt: Text("이메일 입력")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color.promptLabelColor))
+                    .padding(.vertical, 5)
+                    .padding(.horizontal, 20)
+                    .autocapitalization(.none)
+                    
+                    HStack {
+                        Spacer()
+                        Button {
+                            viewModel.clearEmailTextField()
+                        } label: {
+                            Image(systemName: "multiply.circle.fill")
+                                .font(.system(size: 15))
+                                .foregroundStyle(Color.promptLabelColor)
+                        }
+                        .frame(width: 10, height: 10)
+                        .padding(.trailing, 10)
+                        .disabled(viewModel.isClearEmailButtonInactive())
+                        .opacity(viewModel.isClearEmailButtonInactive() ? 0 : 1)
+                        
+                        Button {
+                            // 메일로 인증번호 보내는 기능 필요
+                        } label: {
+                            Text("인증요청")
+                                .font(.system(size: 14, weight: .regular))
+                                .foregroundStyle(.black)
+                                .padding(.vertical, 7)
+                                .padding(.horizontal, 14)
+                        }
+                        .background(.white)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 40)
+                                .stroke(Color.codeRequestButtonColor, lineWidth: 1)
+                        )
+                        .padding(.trailing, 20)
+                    }
+                }
+                
+                Spacer()
+                    .frame(height: 5)
+                
+                Rectangle()
+                    .foregroundStyle(.black)
+                    .frame(height: 1)
+                    .padding(.horizontal, 20)
+                
+                Spacer()
+                    .frame(height: 24)
+                
+                SignUpStep2CautionText(text: "입력한 이메일로 인증번호가 발송됩니다.")
+                SignUpStep2CautionText(text: "인증메일을 받을 수 있도록 자주 쓰는 이메일을 입력해 주세요.")
+                
+                Spacer()
+                    .frame(height: 24)
+                
+                NavigationLink(destination: EmptyView()) {
+                    Text("다음")
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundStyle(.black)
+                        .padding(.vertical, 16)
+                        .frame(maxWidth: .infinity, idealHeight: 51)
+                        .background(viewModel.isCodeEntered() ? Color.kakaoYellow : Color.disabledNextButtonColor)
+                        .cornerRadius(6)
+                }
+                .padding(.horizontal, 20)
+                .disabled(viewModel.isCodeEntered() == false)
+                
+                Spacer()
+            }
+        }
     }
+}
+
+struct SignUpStep2CautionText: View {
+    let text: String
+    var body: some View {
+        HStack(spacing: 7) {
+            Circle()
+                .frame(width: 2, height: 2)
+            Text(text)
+                .font(.system(size: 11, weight: .light))
+            Spacer()
+        }
+        .foregroundStyle(Color.emailCautionTextGray)
+        .padding(.horizontal, 20)
+    }
+}
+
+extension Color {
+    static let codeRequestButtonColor: Color = .init(red: 208 / 255, green: 208 / 255, blue: 208 / 255)  // 인증 요청 버튼 테두리 색상
+    static let disabledNextButtonColor: Color = .init(red: 240 / 255, green: 240 / 255, blue: 240 / 255)  // 다음 버튼 이용 불가능 색상
+    static let emailCautionTextGray: Color = .init(red: 153 / 255, green: 153 / 255, blue: 153 / 255)  // 다음 버튼 이용 불가능 색상
+}
+
+#Preview {
+    SignUpStep2EmailView()
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -135,14 +135,26 @@ struct SignUpStep2EmailView: View {
                         }
                     }
                 }
-                
+
                 Spacer()
                     .frame(height: 5)
                 
                 Rectangle()
-                    .foregroundStyle(.black)
+                    .foregroundStyle(viewModel.isEmptyEmailRequested() ? Color.emptyEmailWarnRed : .black)
                     .frame(height: 1)
                     .padding(.horizontal, 20)
+                
+                if viewModel.isEmptyEmailRequested() {
+                    Spacer()
+                        .frame(height: 5)
+                    HStack {
+                        Text("와스토리 계정 이메일을 입력해 주세요.")
+                            .font(.system(size: 11, weight: .light))
+                            .foregroundStyle(Color.emptyEmailWarnRed)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 20)
+                }
                 
                 Spacer()
                     .frame(height: 24)
@@ -191,6 +203,7 @@ extension Color {
     static let codeRequestButtonGray: Color = .init(red: 208 / 255, green: 208 / 255, blue: 208 / 255)  // 인증 요청 버튼 테두리 색상
     static let disabledNextButtonGray: Color = .init(red: 240 / 255, green: 240 / 255, blue: 240 / 255)  // 다음 버튼 이용 불가능 색상
     static let emailCautionTextGray: Color = .init(red: 153 / 255, green: 153 / 255, blue: 153 / 255)  // 다음 버튼 이용 불가능 색상
+    static let emptyEmailWarnRed: Color = .init(red: 208 / 255, green: 104 / 255, blue: 79 / 255)  // 이메일 미입력 경고 색상
 }
 
 #Preview {

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -34,7 +34,7 @@ struct SignUpStep2EmailView: View {
                 .padding(.top, 20)
                 
                 HStack {
-                    Text("와스토리 계정으로 사용할")
+                    Text(viewModel.isCodeRequired() ? "이메일로 발송된" : "와스토리 계정으로 사용할")
                         .font(.system(size: 18, weight: .regular))
                         .padding(.horizontal, 20)
                     Spacer()
@@ -43,7 +43,7 @@ struct SignUpStep2EmailView: View {
                 Spacer()
                     .frame(height: 5)
                 HStack {
-                    Text("이메일을 입력해 주세요.")
+                    Text(viewModel.isCodeRequired() ? "인증번호를 입력해 주세요." : "이메일을 입력해 주세요.")
                         .font(.system(size: 18, weight: .regular))
                         .padding(.horizontal, 20)
                     Spacer()
@@ -52,43 +52,82 @@ struct SignUpStep2EmailView: View {
                 Spacer()
                     .frame(height: 30)
                 
-                ZStack {
-                    TextField("", text: $viewModel.email, prompt: Text("이메일 입력")
-                        .font(.system(size: 14))
-                        .foregroundStyle(Color.promptLabelColor))
-                    .padding(.vertical, 5)
-                    .padding(.horizontal, 20)
-                    .autocapitalization(.none)
-                    
+                if viewModel.isCodeRequired() {
                     HStack {
+                        Text(viewModel.email)
+                            .foregroundStyle(Color.promptLabelColor)
+                            .padding(.vertical, 5)
                         Spacer()
-                        Button {
-                            viewModel.clearEmailTextField()
-                        } label: {
-                            Image(systemName: "multiply.circle.fill")
-                                .font(.system(size: 15))
-                                .foregroundStyle(Color.promptLabelColor)
-                        }
-                        .frame(width: 10, height: 10)
-                        .padding(.trailing, 10)
-                        .disabled(viewModel.isClearEmailButtonInactive())
-                        .opacity(viewModel.isClearEmailButtonInactive() ? 0 : 1)
+                    }
+                    .padding(.horizontal, 20)
+                    Spacer()
+                        .frame(height: 5)
+                    Rectangle()
+                        .foregroundStyle(Color.promptLabelColor)
+                        .frame(height: 1)
+                        .padding(.horizontal, 20)
+                }
+                
+                ZStack {
+                    if viewModel.isCodeRequired() {
+                        TextField("", text: $viewModel.code, prompt: Text("인증번호 8자 입력")
+                            .foregroundStyle(Color.promptLabelColor))
+                        .padding(.vertical, 5)
+                        .padding(.horizontal, 20)
+                        .autocapitalization(.none)
                         
-                        Button {
-                            // 메일로 인증번호 보내는 기능 필요
-                        } label: {
-                            Text("인증요청")
-                                .font(.system(size: 14, weight: .regular))
-                                .foregroundStyle(.black)
-                                .padding(.vertical, 7)
-                                .padding(.horizontal, 14)
+                        HStack {
+                            Spacer()
+                            Button {
+                                viewModel.clearCodeTextField()
+                            } label: {
+                                Image(systemName: "multiply.circle.fill")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(Color.promptLabelColor)
+                            }
+                            .frame(width: 10, height: 10)
+                            .padding(.trailing, 24)
+                            .disabled(viewModel.isClearCodeButtonInactive())
+                            .opacity(viewModel.isClearCodeButtonInactive() ? 0 : 1)
                         }
-                        .background(.white)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 40)
-                                .stroke(Color.codeRequestButtonGray, lineWidth: 1)
-                        )
-                        .padding(.trailing, 20)
+                    }
+                    else {
+                        TextField("", text: $viewModel.email, prompt: Text("이메일 입력")
+                            .foregroundStyle(Color.promptLabelColor))
+                        .padding(.vertical, 5)
+                        .padding(.horizontal, 20)
+                        .autocapitalization(.none)
+                        
+                        HStack {
+                            Spacer()
+                            Button {
+                                viewModel.clearEmailTextField()
+                            } label: {
+                                Image(systemName: "multiply.circle.fill")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(Color.promptLabelColor)
+                            }
+                            .frame(width: 10, height: 10)
+                            .padding(.trailing, 10)
+                            .disabled(viewModel.isClearEmailButtonInactive())
+                            .opacity(viewModel.isClearEmailButtonInactive() ? 0 : 1)
+                            
+                            Button {
+                                viewModel.requestCode()
+                            } label: {
+                                Text("인증요청")
+                                    .font(.system(size: 14, weight: .regular))
+                                    .foregroundStyle(.black)
+                                    .padding(.vertical, 7)
+                                    .padding(.horizontal, 14)
+                            }
+                            .background(.white)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 40)
+                                    .stroke(Color.codeRequestButtonGray, lineWidth: 1)
+                            )
+                            .padding(.trailing, 20)
+                        }
                     }
                 }
                 
@@ -103,11 +142,12 @@ struct SignUpStep2EmailView: View {
                 Spacer()
                     .frame(height: 24)
                 
-                SignUpStep2CautionText(text: "입력한 이메일로 인증번호가 발송됩니다.")
-                SignUpStep2CautionText(text: "인증메일을 받을 수 있도록 자주 쓰는 이메일을 입력해 주세요.")
-                
-                Spacer()
-                    .frame(height: 24)
+                if viewModel.isCodeRequired() == false {
+                    SignUpStep2CautionText(text: "입력한 이메일로 인증번호가 발송됩니다.")
+                    SignUpStep2CautionText(text: "인증메일을 받을 수 있도록 자주 쓰는 이메일을 입력해 주세요.")
+                    Spacer()
+                        .frame(height: 24)
+                }
                 
                 NavigationLink(destination: EmptyView()) {
                     Text("다음")

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -165,6 +165,22 @@ struct SignUpStep2EmailView: View {
                     Spacer()
                         .frame(height: 24)
                 }
+                else {
+                    Button {
+                    } label: {
+                        HStack {
+                            Text("인증메일을 받지 못하셨나요?")
+                                .font(.system(size: 11, weight: .regular))
+                                .foregroundStyle(.black)
+                                .underline()
+                            Spacer()
+                        }
+                        .padding(.horizontal, 20)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    Spacer()
+                        .frame(height: 24)
+                }
                 
                 NavigationLink(destination: EmptyView()) {
                     Text("다음")

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -143,8 +143,8 @@ struct SignUpStep2CautionText: View {
 }
 
 extension Color {
-    static let codeRequestButtonColor: Color = .init(red: 208 / 255, green: 208 / 255, blue: 208 / 255)  // 인증 요청 버튼 테두리 색상
-    static let disabledNextButtonColor: Color = .init(red: 240 / 255, green: 240 / 255, blue: 240 / 255)  // 다음 버튼 이용 불가능 색상
+    static let codeRequestButtonGray: Color = .init(red: 208 / 255, green: 208 / 255, blue: 208 / 255)  // 인증 요청 버튼 테두리 색상
+    static let disabledNextButtonGray: Color = .init(red: 240 / 255, green: 240 / 255, blue: 240 / 255)  // 다음 버튼 이용 불가능 색상
     static let emailCautionTextGray: Color = .init(red: 153 / 255, green: 153 / 255, blue: 153 / 255)  // 다음 버튼 이용 불가능 색상
 }
 

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -1,0 +1,16 @@
+//
+//  SignUpStep3PasswordView.swift
+//  Wastory
+//
+//  Created by mujigae on 1/2/25.
+//
+
+import SwiftUI
+
+struct SignUpStep3PasswordView: View {
+    @State private var viewModel = SignUpStep3ViewModel()
+    
+    var body: some View {
+        Text("비밀번호 설정 뷰")
+    }
+}

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -9,5 +9,28 @@ import SwiftUI
 import Observation
 
 @Observable final class SignUpStep2ViewModel {
-
+    var email: String = ""
+    var code: String = ""
+    
+    private let codeLength: Int = 6
+    
+    func clearEmailTextField() {
+        email = ""
+    }
+    
+    func isClearEmailButtonInactive() -> Bool {
+        return email.isEmpty
+    }
+    
+    func clearCodeTextField() {
+        code = ""
+    }
+    
+    func isClearCodeButtonInactive() -> Bool {
+        return code.isEmpty
+    }
+    
+    func isCodeEntered() -> Bool {
+        return code.count == codeLength
+    }
 }

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -20,6 +20,17 @@ import Observation
     private var emptyCodeEntered: Bool = false
     private var invalidCodeEntered: Bool = false
     
+    func requestEmailReentry() {
+        // 이메일 입력화면으로 되돌아가는 버튼
+        email = ""
+        code = ""
+        isCodeRequested = false
+        emptyEmailRequested = false
+        invalidEmailRequested = false
+        emptyCodeEntered = false
+        invalidCodeEntered = false
+    }
+    
     // MARK: Email TextField
     func clearEmailTextField() {
         email = ""

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -13,6 +13,7 @@ import Observation
     var code: String = ""
     
     private var isCodeRequested: Bool = false
+    private var emptyEmailRequested: Bool = false
     
     private let codeLength: Int = 8
     
@@ -25,8 +26,18 @@ import Observation
     }
     
     func requestCode() {
-        isCodeRequested = true
-        // 이메일 인증번호 보내는 기능 필요
+        if email.isEmpty == false {
+            isCodeRequested = true
+            emptyEmailRequested = false
+            // 이메일 인증번호 보내는 기능 필요
+        }
+        else {
+            emptyEmailRequested = true
+        }
+    }
+    
+    func isEmptyEmailRequested() -> Bool {
+        return emptyEmailRequested
     }
     
     func isCodeRequired() -> Bool {

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -17,6 +17,8 @@ import Observation
     private var invalidEmailRequested: Bool = false
     
     private let codeLength: Int = 8
+    private var emptyCodeEntered: Bool = false
+    private var invalidCodeEntered: Bool = false
     
     // MARK: Email TextField
     func clearEmailTextField() {
@@ -26,8 +28,6 @@ import Observation
     func isClearEmailButtonInactive() -> Bool {
         return email.isEmpty
     }
-    
-    
     
     func requestCode() {
         if email.isEmpty {
@@ -53,6 +53,12 @@ import Observation
         return invalidEmailRequested
     }
     
+    func isValidEmail(_ email: String) -> Bool {
+        let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+        let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+        return emailPredicate.evaluate(with: email)
+    }
+    
     // MARK: Verification Code TextField
     func isCodeRequired() -> Bool {
         return isCodeRequested
@@ -66,13 +72,30 @@ import Observation
         return code.isEmpty
     }
     
-    func isCodeEntered() -> Bool {
-        return code.count == codeLength
+    func isEmptyCodeEntered() -> Bool {
+        return emptyCodeEntered
     }
-}
-
-func isValidEmail(_ email: String) -> Bool {
-    let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
-    let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
-    return emailPredicate.evaluate(with: email)
+    
+    func isInvalidCodeEntered() -> Bool {
+        return invalidCodeEntered
+    }
+    
+    func checkCodeValidty(_ code: String) {
+        if code.isEmpty {
+            invalidCodeEntered = false
+        }
+        else {
+            emptyCodeEntered = false
+            invalidCodeEntered = !code.allSatisfy { $0.isNumber } || code.count < 8
+        }
+    }
+    
+    func isVerificationSuccessful() -> Bool {
+        // 인증코드 유효성 검사 코드 필요
+        if code.isEmpty {
+            emptyCodeEntered = true
+            return false
+        }
+        return !code.isEmpty && !invalidCodeEntered
+    }
 }

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -14,9 +14,11 @@ import Observation
     
     private var isCodeRequested: Bool = false
     private var emptyEmailRequested: Bool = false
+    private var invalidEmailRequested: Bool = false
     
     private let codeLength: Int = 8
     
+    // MARK: Email TextField
     func clearEmailTextField() {
         email = ""
     }
@@ -25,14 +27,21 @@ import Observation
         return email.isEmpty
     }
     
+    
+    
     func requestCode() {
-        if email.isEmpty == false {
+        if email.isEmpty {
+            invalidEmailRequested = false
+            emptyEmailRequested = true
+        }
+        else if isValidEmail(email) {
             isCodeRequested = true
             emptyEmailRequested = false
-            // 이메일 인증번호 보내는 기능 필요
+            invalidEmailRequested = false
         }
         else {
-            emptyEmailRequested = true
+            emptyEmailRequested = false
+            invalidEmailRequested = true
         }
     }
     
@@ -40,6 +49,11 @@ import Observation
         return emptyEmailRequested
     }
     
+    func isInvalidEmailRequested() -> Bool {
+        return invalidEmailRequested
+    }
+    
+    // MARK: Verification Code TextField
     func isCodeRequired() -> Bool {
         return isCodeRequested
     }
@@ -55,4 +69,10 @@ import Observation
     func isCodeEntered() -> Bool {
         return code.count == codeLength
     }
+}
+
+func isValidEmail(_ email: String) -> Bool {
+    let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+    let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+    return emailPredicate.evaluate(with: email)
 }

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -12,7 +12,9 @@ import Observation
     var email: String = ""
     var code: String = ""
     
-    private let codeLength: Int = 6
+    private var isCodeRequested: Bool = false
+    
+    private let codeLength: Int = 8
     
     func clearEmailTextField() {
         email = ""
@@ -20,6 +22,15 @@ import Observation
     
     func isClearEmailButtonInactive() -> Bool {
         return email.isEmpty
+    }
+    
+    func requestCode() {
+        isCodeRequested = true
+        // 이메일 인증번호 보내는 기능 필요
+    }
+    
+    func isCodeRequired() -> Bool {
+        return isCodeRequested
     }
     
     func clearCodeTextField() {

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep3ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep3ViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  SignUpStep3ViewModel.swift
+//  Wastory
+//
+//  Created by mujigae on 1/2/25.
+//
+
+import SwiftUI
+import Observation
+
+@Observable final class SignUpStep3ViewModel {
+
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

-[O] 기능 추가 
-[] 기능 삭제
 -[] 버그 수정
 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 

feature/add-signup-email-view -> main

### 변경 사항 

SignUpStep2EmailView, SignUpStep2ViewModel 구현 (이메일 인증 및 유저 ID 결정 화면)

### 추후 보완 사항

회원가입 중 나오는 백버튼은 추후 일괄적으로 검은색 백버튼으로 수정 예정
이메일 인증을 위한 API를 서버와 연결하는 작업 필요

참고 영상

https://github.com/user-attachments/assets/caf73ce8-531d-4d4c-9b42-e63141a3b4b1

만들다 보니 다른 화면에 비해 생각보다 많은 디테일이 숨어 있어 코드가 매우 길어졌습니다.