### PR TITLE
Feat: Implement SignUp View Step3, Step4 - Password View, Welcome View

### DIFF
--- a/Wastory/Wastory/View/CustomBackButton.swift
+++ b/Wastory/Wastory/View/CustomBackButton.swift
@@ -1,0 +1,21 @@
+//
+//  CustomBackButton.swift
+//  Wastory
+//
+//  Created by mujigae on 1/7/25.
+//
+
+import SwiftUI
+
+struct CustomBackButton: View {
+    @Environment(\.dismiss) private var dismiss
+    var body: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "chevron.left")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.black)
+        }
+    }
+}

--- a/Wastory/Wastory/View/SignView/SignUpStep1TermsView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep1TermsView.swift
@@ -120,5 +120,11 @@ struct SignUpStep1TermsView: View {
                 Spacer()
             }
         }
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                CustomBackButton()
+            }
+        }
     }
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -11,6 +11,7 @@ struct SignUpStep2EmailView: View {
     @State private var viewModel = SignUpStep2ViewModel()
     @State private var showRerequestEmailBox = false
     @FocusState private var isEmailFocused: Bool
+    @FocusState private var isCodeFocused: Bool
     
     var body: some View {
         NavigationStack {
@@ -19,6 +20,7 @@ struct SignUpStep2EmailView: View {
                     .contentShape(Rectangle())
                     .onTapGesture {
                         isEmailFocused = false
+                        isCodeFocused = false
                     }
                 
                 VStack {
@@ -81,6 +83,7 @@ struct SignUpStep2EmailView: View {
                         if viewModel.isCodeRequired() {
                             TextField("", text: $viewModel.code, prompt: Text("인증번호 8자 입력")
                                 .foregroundStyle(Color.promptLabelColor))
+                            .focused($isCodeFocused)
                             .keyboardType(.numberPad)
                             .padding(.vertical, 5)
                             .padding(.horizontal, 20)

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SignUpStep2EmailView: View {
     @State private var viewModel = SignUpStep2ViewModel()
-    @State private var isNavigationActive = false
     @State private var showRerequestEmailBox = false
     
     var body: some View {
@@ -188,23 +187,35 @@ struct SignUpStep2EmailView: View {
                             .frame(height: 24)
                     }
                     
-                    Button {
-                        if viewModel.isVerificationSuccessful() {
-                            isNavigationActive = true
-                            UserInfoRepository.shared.setUserID(userID: viewModel.email)    // UserID (email) 결정
+                    ZStack {
+                        NavigationLink(destination: SignUpStep3PasswordView()) {
+                            Text("다음")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(.black)
+                                .padding(.vertical, 16)
+                                .frame(maxWidth: .infinity, idealHeight: 51)
+                                .background(Color.kakaoYellow)
+                                .cornerRadius(6)
                         }
-                    } label: {
-                        Text("다음")
-                            .font(.system(size: 16, weight: .regular))
-                            .foregroundStyle(.black)
-                            .padding(.vertical, 16)
-                            .frame(maxWidth: .infinity, idealHeight: 51)
-                            .background(viewModel.code.isEmpty || viewModel.isInvalidCodeEntered() ? Color.disabledNextButtonGray : Color.kakaoYellow)
-                            .cornerRadius(6)
-                    }
-                    .padding(.horizontal, 20)
-                    .navigationDestination(isPresented: $isNavigationActive) {
-                        SignUpStep3PasswordView()
+                        .padding(.horizontal, 20)
+                        .disabled(!viewModel.isVerificationSuccessful())
+                        .opacity(viewModel.isVerificationSuccessful() ? 1 : 0)
+                        
+                        Button {
+                            if viewModel.isVerificationSuccessful() {
+                                UserInfoRepository.shared.setUserID(userID: viewModel.email)    // UserID (email) 결정
+                            }
+                        } label: {
+                            Text("다음")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(.black)
+                                .padding(.vertical, 16)
+                                .frame(maxWidth: .infinity, idealHeight: 51)
+                                .background(viewModel.code.isEmpty || viewModel.isInvalidCodeEntered() ? Color.disabledNextButtonGray : Color.kakaoYellow)
+                                .cornerRadius(6)
+                        }
+                        .padding(.horizontal, 20)
+                        .opacity(viewModel.isVerificationSuccessful() ? 0 : 1)
                     }
                     
                     Spacer()

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -301,7 +301,7 @@ struct SignUpStep2CautionText: View {
             Circle()
                 .frame(width: 2, height: 2)
             Text(text)
-                .font(.system(size: 11, weight: .light))
+                .font(.system(size: 10, weight: .light))
             Spacer()
         }
         .foregroundStyle(Color.emailCautionTextGray)

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -22,7 +22,12 @@ struct SignUpStep2EmailView: View {
                     .onTapGesture {
                         isEmailFocused = false
                         isCodeFocused = false
-                        viewModel.touchEmailScreen()
+                        if viewModel.isCodeRequired() {
+                            viewModel.touchCodeScreen()
+                        }
+                        else {
+                            viewModel.touchEmailScreen()
+                        }
                         viewModel.untapNextButton()
                     }
                 
@@ -92,10 +97,9 @@ struct SignUpStep2EmailView: View {
                             .padding(.horizontal, 20)
                             .autocapitalization(.none)
                             .onChange(of: viewModel.code) { newValue, oldValue in
-                                if oldValue.count >= 8 {
-                                    viewModel.code = String(viewModel.code.prefix(8))
+                                if oldValue.count >= viewModel.getCodeLength() {
+                                    viewModel.code = String(viewModel.code.prefix(viewModel.getCodeLength()))
                                 }
-                                viewModel.checkCodeValidty(oldValue)
                             }
                             
                             HStack {
@@ -162,7 +166,7 @@ struct SignUpStep2EmailView: View {
                     
                     if viewModel.isCodeRequired() {
                         Rectangle()
-                            .foregroundStyle( (viewModel.isCodeRequired() && (viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered())) ? Color.emptyEmailWarnRed : .black)
+                            .foregroundStyle(isCodeFocused ? .black : viewModel.codeValidator().isEmpty || !viewModel.isCodeScreenTouched() ? Color.emailCautionTextGray : Color.emptyEmailWarnRed)
                             .frame(height: 1)
                             .padding(.horizontal, 20)
                     }
@@ -174,11 +178,11 @@ struct SignUpStep2EmailView: View {
                     }
                     
                     if viewModel.isCodeRequired() {
-                        if viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered() {
+                        if !isCodeFocused && viewModel.isCodeScreenTouched() &&  !viewModel.codeValidator().isEmpty {
                             Spacer()
                                 .frame(height: 5)
                             HStack {
-                                Text(viewModel.isEmptyCodeEntered() ? "이메일로 발송된 인증번호를 입력해 주세요." : "인증번호 형식이 올바르지 않습니다.")
+                                Text(viewModel.codeValidator())
                                     .font(.system(size: 11, weight: .light))
                                     .foregroundStyle(Color.emptyEmailWarnRed)
                                 Spacer()
@@ -248,7 +252,12 @@ struct SignUpStep2EmailView: View {
                         
                         Button {
                             isEmailFocused = false
-                            viewModel.touchEmailScreen()
+                            if viewModel.isCodeRequired() {
+                                viewModel.touchCodeScreen()
+                            }
+                            else {
+                                viewModel.touchEmailScreen()
+                            }
                             viewModel.tapNextButton()
                         } label: {
                             Text("다음")
@@ -256,7 +265,7 @@ struct SignUpStep2EmailView: View {
                                 .foregroundStyle(.black)
                                 .padding(.vertical, 16)
                                 .frame(maxWidth: .infinity, idealHeight: 51)
-                                .background(viewModel.code.isEmpty || viewModel.isInvalidCodeEntered() ? Color.disabledNextButtonGray : Color.kakaoYellow)
+                                .background(viewModel.codeValidator().isEmpty ? Color.kakaoYellow : Color.disabledNextButtonGray)
                                 .cornerRadius(6)
                         }
                         .padding(.horizontal, 20)

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -252,6 +252,7 @@ struct SignUpStep2EmailView: View {
                         
                         Button {
                             isEmailFocused = false
+                            isCodeFocused = false
                             if viewModel.isCodeRequired() {
                                 viewModel.touchCodeScreen()
                             }

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -316,6 +316,12 @@ struct SignUpStep2EmailView: View {
                 }
             }
         }
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                CustomBackButton()
+            }
+        }
     }
 }
 

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -210,12 +210,15 @@ struct SignUpStep2EmailView: View {
                         }
                         .padding(.horizontal, 20)
                         .disabled(!viewModel.isVerificationSuccessful())
+                        .simultaneousGesture(
+                            TapGesture().onEnded {
+                                UserInfoRepository.shared.setUserID(userID: viewModel.email)    // UserID (email) 결정
+                            }
+                        )
                         .opacity(viewModel.isVerificationSuccessful() ? 1 : 0)
                         
                         Button {
-                            if viewModel.isVerificationSuccessful() {
-                                UserInfoRepository.shared.setUserID(userID: viewModel.email)    // UserID (email) 결정
-                            }
+                            print(2)
                         } label: {
                             Text("다음")
                                 .font(.system(size: 16, weight: .regular))

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -10,10 +10,17 @@ import SwiftUI
 struct SignUpStep2EmailView: View {
     @State private var viewModel = SignUpStep2ViewModel()
     @State private var showRerequestEmailBox = false
+    @FocusState private var isEmailFocused: Bool
     
     var body: some View {
         NavigationStack {
             ZStack {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        isEmailFocused = false
+                    }
+                
                 VStack {
                     ZStack {
                         HStack {
@@ -103,6 +110,7 @@ struct SignUpStep2EmailView: View {
                         else {
                             TextField("", text: $viewModel.email, prompt: Text("이메일 입력")
                                 .foregroundStyle(Color.promptLabelColor))
+                            .focused($isEmailFocused)
                             .padding(.vertical, 5)
                             .padding(.horizontal, 20)
                             .autocapitalization(.none)

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SignUpStep2EmailView: View {
     @State private var viewModel = SignUpStep2ViewModel()
     @State private var showRerequestEmailBox = false
+    
     @FocusState private var isEmailFocused: Bool
     @FocusState private var isCodeFocused: Bool
     
@@ -21,6 +22,8 @@ struct SignUpStep2EmailView: View {
                     .onTapGesture {
                         isEmailFocused = false
                         isCodeFocused = false
+                        viewModel.touchEmailScreen()
+                        viewModel.untapNextButton()
                     }
                 
                 VStack {
@@ -133,6 +136,9 @@ struct SignUpStep2EmailView: View {
                                 .opacity(viewModel.isClearEmailButtonInactive() ? 0 : 1)
                                 
                                 Button {
+                                    isEmailFocused = false
+                                    viewModel.touchEmailScreen()
+                                    viewModel.untapNextButton()
                                     viewModel.requestCode()
                                 } label: {
                                     Text("인증요청")
@@ -154,21 +160,44 @@ struct SignUpStep2EmailView: View {
                     Spacer()
                         .frame(height: 5)
                     
-                    Rectangle()
-                        .foregroundStyle(viewModel.isEmptyEmailRequested() || viewModel.isInvalidEmailRequested() || viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered() ? Color.emptyEmailWarnRed : .black)
-                        .frame(height: 1)
-                        .padding(.horizontal, 20)
+                    if viewModel.isCodeRequired() {
+                        Rectangle()
+                            .foregroundStyle( (viewModel.isCodeRequired() && (viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered())) ? Color.emptyEmailWarnRed : .black)
+                            .frame(height: 1)
+                            .padding(.horizontal, 20)
+                    }
+                    else {
+                        Rectangle()
+                            .foregroundStyle(isEmailFocused ? .black : viewModel.emailValidator().isEmpty || !viewModel.isEmailScreenTouched() ? Color.emailCautionTextGray : Color.emptyEmailWarnRed)
+                            .frame(height: 1)
+                            .padding(.horizontal, 20)
+                    }
                     
-                    if viewModel.isEmptyEmailRequested() || viewModel.isInvalidEmailRequested() || viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered() {
-                        Spacer()
-                            .frame(height: 5)
-                        HStack {
-                            Text(viewModel.isEmptyEmailRequested() ? "와스토리 계정 이메일을 입력해 주세요." : viewModel.isInvalidEmailRequested() ?  "와스토리 계정 이메일 형식이 올바르지 않습니다." : viewModel.isEmptyCodeEntered() ? "이메일로 발송된 인증번호를 입력해 주세요." : "인증번호 형식이 올바르지 않습니다.")
-                                .font(.system(size: 11, weight: .light))
-                                .foregroundStyle(Color.emptyEmailWarnRed)
+                    if viewModel.isCodeRequired() {
+                        if viewModel.isEmptyCodeEntered() || viewModel.isInvalidCodeEntered() {
                             Spacer()
+                                .frame(height: 5)
+                            HStack {
+                                Text(viewModel.isEmptyCodeEntered() ? "이메일로 발송된 인증번호를 입력해 주세요." : "인증번호 형식이 올바르지 않습니다.")
+                                    .font(.system(size: 11, weight: .light))
+                                    .foregroundStyle(Color.emptyEmailWarnRed)
+                                Spacer()
+                            }
+                            .padding(.horizontal, 20)
                         }
-                        .padding(.horizontal, 20)
+                    }
+                    else {
+                        if !isEmailFocused && viewModel.isEmailScreenTouched() && !viewModel.emailValidator().isEmpty {
+                            Spacer()
+                                .frame(height: 5)
+                            HStack {
+                                Text(viewModel.emailValidator())
+                                    .font(.system(size: 11, weight: .light))
+                                    .foregroundStyle(Color.emptyEmailWarnRed)
+                                    .padding(.horizontal, 20)
+                                Spacer()
+                            }
+                        }
                     }
                     
                     Spacer()
@@ -218,7 +247,9 @@ struct SignUpStep2EmailView: View {
                         .opacity(viewModel.isVerificationSuccessful() ? 1 : 0)
                         
                         Button {
-                            print(2)
+                            isEmailFocused = false
+                            viewModel.touchEmailScreen()
+                            viewModel.tapNextButton()
                         } label: {
                             Text("다음")
                                 .font(.system(size: 16, weight: .regular))

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -11,7 +11,7 @@ struct SignUpStep3PasswordView: View {
     @State private var viewModel = SignUpStep3ViewModel()
     @FocusState private var isPasswordFocused: Bool
     @FocusState private var isPassword2Focused: Bool
-    
+
     var body: some View {
         VStack {
             HStack {
@@ -167,17 +167,33 @@ struct SignUpStep3PasswordView: View {
             Spacer()
                 .frame(height: 24)
             
-            Button {
-            } label: {
-                Text("다음")
-                    .font(.system(size: 16, weight: .regular))
-                    .foregroundStyle(.black)
-                    .padding(.vertical, 16)
-                    .frame(maxWidth: .infinity, idealHeight: 51)
-                    .background(true ? Color.disabledNextButtonGray : Color.kakaoYellow)
-                    .cornerRadius(6)
+            ZStack {
+                NavigationLink(destination: SignUpStep4WelcomeView()) {
+                    Text("다음")
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundStyle(.black)
+                        .padding(.vertical, 16)
+                        .frame(maxWidth: .infinity, idealHeight: 51)
+                        .background(Color.kakaoYellow)
+                        .cornerRadius(6)
+                }
+                .padding(.horizontal, 20)
+                .disabled(!viewModel.isEqualPassword())
+                .opacity(viewModel.isEqualPassword() ? 1 : 0)
+                
+                Button {
+                } label: {
+                    Text("다음")
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundStyle(.black)
+                        .padding(.vertical, 16)
+                        .frame(maxWidth: .infinity, idealHeight: 51)
+                        .background( Color.disabledNextButtonGray)
+                        .cornerRadius(6)
+                }
+                .padding(.horizontal, 20)
+                .opacity(viewModel.isEqualPassword() ? 0 : 1)
             }
-            .padding(.horizontal, 20)
             
             Spacer()
         }
@@ -186,8 +202,4 @@ struct SignUpStep3PasswordView: View {
             isPassword2Focused = false
         }
     }
-}
-
-#Preview {
-    SignUpStep3PasswordView()
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -190,6 +190,11 @@ struct SignUpStep3PasswordView: View {
                         }
                         .padding(.horizontal, 20)
                         .disabled(!viewModel.isPasswordValid())
+                        .simultaneousGesture(
+                            TapGesture().onEnded {
+                                UserInfoRepository.shared.setUserPW(userPW: viewModel.password)    // UserPW 결정
+                            }
+                        )
                         .opacity(viewModel.isPasswordValid() ? 1 : 0)
                         
                         Button {

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -11,6 +11,148 @@ struct SignUpStep3PasswordView: View {
     @State private var viewModel = SignUpStep3ViewModel()
     
     var body: some View {
-        Text("비밀번호 설정 뷰")
+        VStack {
+            HStack {
+                Rectangle()
+                    .foregroundStyle(Color.progressBarProgressColor)
+                    .frame(width: 60, height: 5)
+                    .cornerRadius(12)
+                    .padding(.leading, 20)
+                Spacer()
+            }
+            .padding(.top, 20)
+            
+            HStack {
+                Text("와스토리 계정 로그인에 사용할")
+                    .font(.system(size: 18, weight: .regular))
+                    .padding(.horizontal, 20)
+                Spacer()
+            }
+            .padding(.top, 24)
+            Spacer()
+                .frame(height: 5)
+            HStack {
+                Text("비밀번호를 등록해 주세요.")
+                    .font(.system(size: 18, weight: .regular))
+                    .padding(.horizontal, 20)
+                Spacer()
+            }
+            Spacer()
+                .frame(height: 30)
+            
+            HStack {
+                Text("와스토리 계정")
+                    .foregroundStyle(Color.emailCautionTextGray)
+                    .font(.system(size: 12))
+                    .padding(.horizontal, 20)
+                Spacer()
+            }
+            Spacer()
+                .frame(height: 8)
+            HStack {
+                Text(UserInfoRepository.shared.getUserID())
+                    .foregroundStyle(.black)
+                    .font(.system(size: 17, weight: .semibold))
+                    .padding(.horizontal, 20)
+                Spacer()
+            }
+            Spacer()
+                .frame(height: 30)
+            
+            HStack {
+                Text("비밀번호")
+                    .foregroundStyle(Color.emailCautionTextGray)
+                    .font(.system(size: 12))
+                    .padding(.horizontal, 20)
+                Spacer()
+            }
+            Spacer()
+                .frame(height: 8)
+            ZStack {
+                TextField("", text: $viewModel.password, prompt: Text("비밀번호 입력(8~32자리)")
+                    .foregroundStyle(Color.promptLabelColor))
+                .padding(.vertical, 5)
+                .padding(.horizontal, 20)
+                .autocapitalization(.none)
+                
+                HStack {
+                    Spacer()
+                    Button {
+                        viewModel.clearPasswordTextField()
+                    } label: {
+                        Image(systemName: "multiply.circle.fill")
+                            .font(.system(size: 15))
+                            .foregroundStyle(Color.promptLabelColor)
+                    }
+                    .frame(width: 10, height: 10)
+                    .padding(.trailing, 24)
+                    .disabled(viewModel.isClearPasswordButtonInactive())
+                    .opacity(viewModel.isClearPasswordButtonInactive() ? 0 : 1)
+                }
+            }
+            Spacer()
+                .frame(height: 5)
+            Rectangle()
+                .foregroundStyle(false ? Color.emptyEmailWarnRed : .black)
+                .frame(height: 1)
+                .padding(.horizontal, 20)
+            Spacer()
+                .frame(height: 5)
+            
+            ZStack {
+                TextField("", text: $viewModel.password2, prompt: Text("비밀번호 재입력")
+                    .foregroundStyle(Color.promptLabelColor))
+                .padding(.vertical, 5)
+                .padding(.horizontal, 20)
+                .autocapitalization(.none)
+                
+                HStack {
+                    Spacer()
+                    Button {
+                        viewModel.clearPassword2TextField()
+                    } label: {
+                        Image(systemName: "multiply.circle.fill")
+                            .font(.system(size: 15))
+                            .foregroundStyle(Color.promptLabelColor)
+                    }
+                    .frame(width: 10, height: 10)
+                    .padding(.trailing, 24)
+                    .disabled(viewModel.isClearPassword2ButtonInactive())
+                    .opacity(viewModel.isClearPassword2ButtonInactive() ? 0 : 1)
+                }
+            }
+            Spacer()
+                .frame(height: 5)
+            Rectangle()
+                .foregroundStyle(false ? Color.emptyEmailWarnRed : .black)
+                .frame(height: 1)
+                .padding(.horizontal, 20)
+            Spacer()
+                .frame(height: 24)
+            
+            SignUpStep2CautionText(text: "비밀번호는 8~32자리의 영문 대소문자, 숫자, 특수문자를 조합하여 설정해 주세요.")
+            SignUpStep2CautionText(text: "다른 사이트에서 사용하는 것과 동일하거나 쉬운 비밀번호는 사용하지 마세요")
+            SignUpStep2CautionText(text: "안전한 계정 사용을 위해 비밀번호는 주기적으로 변경해 주세요.")
+            Spacer()
+                .frame(height: 24)
+            
+            Button {
+            } label: {
+                Text("다음")
+                    .font(.system(size: 16, weight: .regular))
+                    .foregroundStyle(.black)
+                    .padding(.vertical, 16)
+                    .frame(maxWidth: .infinity, idealHeight: 51)
+                    .background(true ? Color.disabledNextButtonGray : Color.kakaoYellow)
+                    .cornerRadius(6)
+            }
+            .padding(.horizontal, 20)
+            
+            Spacer()
+        }
     }
+}
+
+#Preview {
+    SignUpStep3PasswordView()
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -202,5 +202,11 @@ struct SignUpStep3PasswordView: View {
                 }
             }
         }
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                CustomBackButton()
+            }
+        }
     }
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -146,10 +146,10 @@ struct SignUpStep3PasswordView: View {
             Spacer()
                 .frame(height: 5)
             Rectangle()
-                .foregroundStyle(isPassword2Focused ? .black : isPasswordFocused || viewModel.isEqualPassword() ? Color.emailCautionTextGray : Color.emptyEmailWarnRed)
+                .foregroundStyle(isPassword2Focused ? .black : !isPasswordSecureFieldRendered || isPasswordFocused || viewModel.isPasswordValid() ? Color.emailCautionTextGray : Color.emptyEmailWarnRed)
                 .frame(height: 1)
                 .padding(.horizontal, 20)
-            if !isPasswordFocused && !isPassword2Focused && !viewModel.isEqualPassword() {
+            if isPasswordSecureFieldRendered && !isPasswordFocused && !isPassword2Focused && !viewModel.isPasswordValid() {
                 Spacer()
                     .frame(height: 5)
                 HStack {
@@ -180,8 +180,8 @@ struct SignUpStep3PasswordView: View {
                         .cornerRadius(6)
                 }
                 .padding(.horizontal, 20)
-                .disabled(!viewModel.isEqualPassword())
-                .opacity(viewModel.isEqualPassword() ? 1 : 0)
+                .disabled(!viewModel.isPasswordValid())
+                .opacity(viewModel.isPasswordValid() ? 1 : 0)
                 
                 Button {
                 } label: {
@@ -194,7 +194,7 @@ struct SignUpStep3PasswordView: View {
                         .cornerRadius(6)
                 }
                 .padding(.horizontal, 20)
-                .opacity(viewModel.isEqualPassword() ? 0 : 1)
+                .opacity(viewModel.isPasswordValid() ? 0 : 1)
             }
             
             Spacer()

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -199,7 +199,7 @@ struct SignUpStep3PasswordView: View {
                                 .foregroundStyle(.black)
                                 .padding(.vertical, 16)
                                 .frame(maxWidth: .infinity, idealHeight: 51)
-                                .background( Color.disabledNextButtonGray)
+                                .background(Color.disabledNextButtonGray)
                                 .cornerRadius(6)
                         }
                         .padding(.horizontal, 20)

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -12,6 +12,7 @@ struct SignUpStep3PasswordView: View {
     @FocusState private var isPasswordFocused: Bool
     @FocusState private var isPassword2Focused: Bool
     @State private var isPasswordSecureFieldRendered: Bool = false
+    @State private var isNavigationActive = false
 
     var body: some View {
         NavigationStack {
@@ -178,37 +179,23 @@ struct SignUpStep3PasswordView: View {
                     Spacer()
                         .frame(height: 24)
                     
-                    ZStack {
-                        NavigationLink(destination: SignUpStep4WelcomeView()) {
-                            Text("다음")
-                                .font(.system(size: 16, weight: .regular))
-                                .foregroundStyle(.black)
-                                .padding(.vertical, 16)
-                                .frame(maxWidth: .infinity, idealHeight: 51)
-                                .background(Color.kakaoYellow)
-                                .cornerRadius(6)
+                    Button {
+                        if viewModel.isPasswordValid() {
+                            isNavigationActive = true
+                            UserInfoRepository.shared.setUserPW(userPW: viewModel.password)
                         }
-                        .padding(.horizontal, 20)
-                        .disabled(!viewModel.isPasswordValid())
-                        .simultaneousGesture(
-                            TapGesture().onEnded {
-                                UserInfoRepository.shared.setUserPW(userPW: viewModel.password)    // UserPW 결정
-                            }
-                        )
-                        .opacity(viewModel.isPasswordValid() ? 1 : 0)
-                        
-                        Button {
-                        } label: {
-                            Text("다음")
-                                .font(.system(size: 16, weight: .regular))
-                                .foregroundStyle(.black)
-                                .padding(.vertical, 16)
-                                .frame(maxWidth: .infinity, idealHeight: 51)
-                                .background(Color.disabledNextButtonGray)
-                                .cornerRadius(6)
-                        }
-                        .padding(.horizontal, 20)
-                        .opacity(viewModel.isPasswordValid() ? 0 : 1)
+                    } label: {
+                        Text("다음")
+                            .font(.system(size: 16, weight: .regular))
+                            .foregroundStyle(.black)
+                            .padding(.vertical, 16)
+                            .frame(maxWidth: .infinity, idealHeight: 51)
+                            .background(viewModel.isPasswordValid() ? Color.kakaoYellow : Color.disabledNextButtonGray)
+                            .cornerRadius(6)
+                    }
+                    .padding(.horizontal, 20)
+                    .navigationDestination(isPresented: $isNavigationActive) {
+                        SignUpStep4WelcomeView()
                     }
                     
                     Spacer()

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -11,6 +11,7 @@ struct SignUpStep3PasswordView: View {
     @State private var viewModel = SignUpStep3ViewModel()
     @FocusState private var isPasswordFocused: Bool
     @FocusState private var isPassword2Focused: Bool
+    @State private var isPasswordSecureFieldRendered: Bool = false
 
     var body: some View {
         VStack {
@@ -78,8 +79,9 @@ struct SignUpStep3PasswordView: View {
                 .padding(.horizontal, 20)
                 .autocapitalization(.none)
                 .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                         isPasswordFocused = true
+                        isPasswordSecureFieldRendered = true
                     }
                 }
                 
@@ -101,12 +103,12 @@ struct SignUpStep3PasswordView: View {
             Spacer()
                 .frame(height: 5)
             Rectangle()
-                .foregroundStyle(isPasswordFocused ? .black : viewModel.passwordValidator().isEmpty ? .emailCautionTextGray : Color.emptyEmailWarnRed)
+                .foregroundStyle(!isPasswordSecureFieldRendered || isPasswordFocused ? .black : viewModel.passwordValidator().isEmpty ? .emailCautionTextGray : Color.emptyEmailWarnRed)
                 .frame(height: 1)
                 .padding(.horizontal, 20)
             Spacer()
                 .frame(height: 5)
-            if !isPasswordFocused && !viewModel.passwordValidator().isEmpty {
+            if isPasswordSecureFieldRendered && !isPasswordFocused && !viewModel.passwordValidator().isEmpty {
                 Spacer()
                     .frame(height: 5)
                 HStack {

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -14,194 +14,201 @@ struct SignUpStep3PasswordView: View {
     @State private var isPasswordSecureFieldRendered: Bool = false
 
     var body: some View {
-        VStack {
-            HStack {
-                Rectangle()
-                    .foregroundStyle(Color.progressBarProgressColor)
-                    .frame(width: 60, height: 5)
-                    .cornerRadius(12)
-                    .padding(.leading, 20)
-                Spacer()
-            }
-            .padding(.top, 20)
-            
-            HStack {
-                Text("와스토리 계정 로그인에 사용할")
-                    .font(.system(size: 18, weight: .regular))
-                    .padding(.horizontal, 20)
-                Spacer()
-            }
-            .padding(.top, 24)
-            Spacer()
-                .frame(height: 5)
-            HStack {
-                Text("비밀번호를 등록해 주세요.")
-                    .font(.system(size: 18, weight: .regular))
-                    .padding(.horizontal, 20)
-                Spacer()
-            }
-            Spacer()
-                .frame(height: 30)
-            
-            HStack {
-                Text("와스토리 계정")
-                    .foregroundStyle(Color.emailCautionTextGray)
-                    .font(.system(size: 12))
-                    .padding(.horizontal, 20)
-                Spacer()
-            }
-            Spacer()
-                .frame(height: 8)
-            HStack {
-                Text(UserInfoRepository.shared.getUserID())
-                    .foregroundStyle(.black)
-                    .font(.system(size: 17, weight: .semibold))
-                    .padding(.horizontal, 20)
-                Spacer()
-            }
-            Spacer()
-                .frame(height: 30)
-            
-            HStack {
-                Text("비밀번호")
-                    .foregroundStyle(Color.emailCautionTextGray)
-                    .font(.system(size: 12))
-                    .padding(.horizontal, 20)
-                Spacer()
-            }
-            Spacer()
-                .frame(height: 8)
+        NavigationStack {
             ZStack {
-                SecureField("", text: $viewModel.password, prompt: Text("비밀번호 입력(8~32자리)")
-                    .foregroundStyle(Color.promptLabelColor))
-                .focused($isPasswordFocused)
-                .padding(.vertical, 5)
-                .padding(.horizontal, 20)
-                .autocapitalization(.none)
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                        isPasswordFocused = true
-                        isPasswordSecureFieldRendered = true
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        isPasswordFocused = false
+                        isPassword2Focused = false
                     }
-                }
                 
-                HStack {
-                    Spacer()
-                    Button {
-                        viewModel.clearPasswordTextField()
-                    } label: {
-                        Image(systemName: "multiply.circle.fill")
-                            .font(.system(size: 15))
-                            .foregroundStyle(Color.promptLabelColor)
+                VStack {
+                    HStack {
+                        Rectangle()
+                            .foregroundStyle(Color.progressBarProgressColor)
+                            .frame(width: 60, height: 5)
+                            .cornerRadius(12)
+                            .padding(.leading, 20)
+                        Spacer()
                     }
-                    .frame(width: 10, height: 10)
-                    .padding(.trailing, 24)
-                    .disabled(viewModel.isClearPasswordButtonInactive())
-                    .opacity(viewModel.isClearPasswordButtonInactive() ? 0 : 1)
-                }
-            }
-            Spacer()
-                .frame(height: 5)
-            Rectangle()
-                .foregroundStyle(!isPasswordSecureFieldRendered || isPasswordFocused ? .black : viewModel.passwordValidator().isEmpty ? .emailCautionTextGray : Color.emptyEmailWarnRed)
-                .frame(height: 1)
-                .padding(.horizontal, 20)
-            Spacer()
-                .frame(height: 5)
-            if isPasswordSecureFieldRendered && !isPasswordFocused && !viewModel.passwordValidator().isEmpty {
-                Spacer()
-                    .frame(height: 5)
-                HStack {
-                    Text(viewModel.passwordValidator())
-                        .font(.system(size: 11, weight: .light))
-                        .foregroundStyle(Color.emptyEmailWarnRed)
+                    .padding(.top, 20)
+                    
+                    HStack {
+                        Text("와스토리 계정 로그인에 사용할")
+                            .font(.system(size: 18, weight: .regular))
+                            .padding(.horizontal, 20)
+                        Spacer()
+                    }
+                    .padding(.top, 24)
+                    Spacer()
+                        .frame(height: 5)
+                    HStack {
+                        Text("비밀번호를 등록해 주세요.")
+                            .font(.system(size: 18, weight: .regular))
+                            .padding(.horizontal, 20)
+                        Spacer()
+                    }
+                    Spacer()
+                        .frame(height: 30)
+                    
+                    HStack {
+                        Text("와스토리 계정")
+                            .foregroundStyle(Color.emailCautionTextGray)
+                            .font(.system(size: 12))
+                            .padding(.horizontal, 20)
+                        Spacer()
+                    }
+                    Spacer()
+                        .frame(height: 8)
+                    HStack {
+                        Text(UserInfoRepository.shared.getUserID())
+                            .foregroundStyle(.black)
+                            .font(.system(size: 17, weight: .semibold))
+                            .padding(.horizontal, 20)
+                        Spacer()
+                    }
+                    Spacer()
+                        .frame(height: 30)
+                    
+                    HStack {
+                        Text("비밀번호")
+                            .foregroundStyle(Color.emailCautionTextGray)
+                            .font(.system(size: 12))
+                            .padding(.horizontal, 20)
+                        Spacer()
+                    }
+                    Spacer()
+                        .frame(height: 8)
+                    ZStack {
+                        SecureField("", text: $viewModel.password, prompt: Text("비밀번호 입력(8~32자리)")
+                            .foregroundStyle(Color.promptLabelColor))
+                        .focused($isPasswordFocused)
+                        .padding(.vertical, 5)
+                        .padding(.horizontal, 20)
+                        .autocapitalization(.none)
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                                isPasswordFocused = true
+                                isPasswordSecureFieldRendered = true
+                            }
+                        }
+                        
+                        HStack {
+                            Spacer()
+                            Button {
+                                viewModel.clearPasswordTextField()
+                            } label: {
+                                Image(systemName: "multiply.circle.fill")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(Color.promptLabelColor)
+                            }
+                            .frame(width: 10, height: 10)
+                            .padding(.trailing, 24)
+                            .disabled(viewModel.isClearPasswordButtonInactive())
+                            .opacity(viewModel.isClearPasswordButtonInactive() ? 0 : 1)
+                        }
+                    }
+                    Spacer()
+                        .frame(height: 5)
+                    Rectangle()
+                        .foregroundStyle(!isPasswordSecureFieldRendered || isPasswordFocused ? .black : viewModel.passwordValidator().isEmpty ? .emailCautionTextGray : Color.emptyEmailWarnRed)
+                        .frame(height: 1)
                         .padding(.horizontal, 20)
                     Spacer()
-                }
-            }
-            
-            ZStack {
-                SecureField("", text: $viewModel.password2, prompt: Text("비밀번호 재입력")
-                    .foregroundStyle(Color.promptLabelColor))
-                .focused($isPassword2Focused)
-                .padding(.vertical, 5)
-                .padding(.horizontal, 20)
-                .autocapitalization(.none)
-                
-                HStack {
-                    Spacer()
-                    Button {
-                        viewModel.clearPassword2TextField()
-                    } label: {
-                        Image(systemName: "multiply.circle.fill")
-                            .font(.system(size: 15))
-                            .foregroundStyle(Color.promptLabelColor)
+                        .frame(height: 5)
+                    if isPasswordSecureFieldRendered && !isPasswordFocused && !viewModel.passwordValidator().isEmpty {
+                        Spacer()
+                            .frame(height: 5)
+                        HStack {
+                            Text(viewModel.passwordValidator())
+                                .font(.system(size: 11, weight: .light))
+                                .foregroundStyle(Color.emptyEmailWarnRed)
+                                .padding(.horizontal, 20)
+                            Spacer()
+                        }
                     }
-                    .frame(width: 10, height: 10)
-                    .padding(.trailing, 24)
-                    .disabled(viewModel.isClearPassword2ButtonInactive())
-                    .opacity(viewModel.isClearPassword2ButtonInactive() ? 0 : 1)
-                }
-            }
-            Spacer()
-                .frame(height: 5)
-            Rectangle()
-                .foregroundStyle(isPassword2Focused ? .black : !isPasswordSecureFieldRendered || isPasswordFocused || viewModel.isPasswordValid() ? Color.emailCautionTextGray : Color.emptyEmailWarnRed)
-                .frame(height: 1)
-                .padding(.horizontal, 20)
-            if isPasswordSecureFieldRendered && !isPasswordFocused && !isPassword2Focused && !viewModel.isPasswordValid() {
-                Spacer()
-                    .frame(height: 5)
-                HStack {
-                    Text("입력한 비밀번호와 재입력한 비밀번호가 일치하지 않습니다.")
-                        .font(.system(size: 11, weight: .light))
-                        .foregroundStyle(Color.emptyEmailWarnRed)
+                    
+                    ZStack {
+                        SecureField("", text: $viewModel.password2, prompt: Text("비밀번호 재입력")
+                            .foregroundStyle(Color.promptLabelColor))
+                        .focused($isPassword2Focused)
+                        .padding(.vertical, 5)
                         .padding(.horizontal, 20)
+                        .autocapitalization(.none)
+                        
+                        HStack {
+                            Spacer()
+                            Button {
+                                viewModel.clearPassword2TextField()
+                            } label: {
+                                Image(systemName: "multiply.circle.fill")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(Color.promptLabelColor)
+                            }
+                            .frame(width: 10, height: 10)
+                            .padding(.trailing, 24)
+                            .disabled(viewModel.isClearPassword2ButtonInactive())
+                            .opacity(viewModel.isClearPassword2ButtonInactive() ? 0 : 1)
+                        }
+                    }
+                    Spacer()
+                        .frame(height: 5)
+                    Rectangle()
+                        .foregroundStyle(isPassword2Focused ? .black : !isPasswordSecureFieldRendered || isPasswordFocused || viewModel.isPasswordValid() ? Color.emailCautionTextGray : Color.emptyEmailWarnRed)
+                        .frame(height: 1)
+                        .padding(.horizontal, 20)
+                    if isPasswordSecureFieldRendered && !isPasswordFocused && !isPassword2Focused && !viewModel.isPasswordValid() {
+                        Spacer()
+                            .frame(height: 5)
+                        HStack {
+                            Text("입력한 비밀번호와 재입력한 비밀번호가 일치하지 않습니다.")
+                                .font(.system(size: 11, weight: .light))
+                                .foregroundStyle(Color.emptyEmailWarnRed)
+                                .padding(.horizontal, 20)
+                            Spacer()
+                        }
+                    }
+                    Spacer()
+                        .frame(height: 24)
+                    
+                    SignUpStep2CautionText(text: "비밀번호는 8~32자리의 영문 대소문자, 숫자, 특수문자를 조합하여 설정해 주세요.")
+                    SignUpStep2CautionText(text: "다른 사이트에서 사용하는 것과 동일하거나 쉬운 비밀번호는 사용하지 마세요")
+                    SignUpStep2CautionText(text: "안전한 계정 사용을 위해 비밀번호는 주기적으로 변경해 주세요.")
+                    Spacer()
+                        .frame(height: 24)
+                    
+                    ZStack {
+                        NavigationLink(destination: SignUpStep4WelcomeView()) {
+                            Text("다음")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(.black)
+                                .padding(.vertical, 16)
+                                .frame(maxWidth: .infinity, idealHeight: 51)
+                                .background(Color.kakaoYellow)
+                                .cornerRadius(6)
+                        }
+                        .padding(.horizontal, 20)
+                        .disabled(!viewModel.isPasswordValid())
+                        .opacity(viewModel.isPasswordValid() ? 1 : 0)
+                        
+                        Button {
+                        } label: {
+                            Text("다음")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(.black)
+                                .padding(.vertical, 16)
+                                .frame(maxWidth: .infinity, idealHeight: 51)
+                                .background( Color.disabledNextButtonGray)
+                                .cornerRadius(6)
+                        }
+                        .padding(.horizontal, 20)
+                        .opacity(viewModel.isPasswordValid() ? 0 : 1)
+                    }
+                    
                     Spacer()
                 }
             }
-            Spacer()
-                .frame(height: 24)
-            
-            SignUpStep2CautionText(text: "비밀번호는 8~32자리의 영문 대소문자, 숫자, 특수문자를 조합하여 설정해 주세요.")
-            SignUpStep2CautionText(text: "다른 사이트에서 사용하는 것과 동일하거나 쉬운 비밀번호는 사용하지 마세요")
-            SignUpStep2CautionText(text: "안전한 계정 사용을 위해 비밀번호는 주기적으로 변경해 주세요.")
-            Spacer()
-                .frame(height: 24)
-            
-            ZStack {
-                NavigationLink(destination: SignUpStep4WelcomeView()) {
-                    Text("다음")
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundStyle(.black)
-                        .padding(.vertical, 16)
-                        .frame(maxWidth: .infinity, idealHeight: 51)
-                        .background(Color.kakaoYellow)
-                        .cornerRadius(6)
-                }
-                .padding(.horizontal, 20)
-                .disabled(!viewModel.isPasswordValid())
-                .opacity(viewModel.isPasswordValid() ? 1 : 0)
-                
-                Button {
-                } label: {
-                    Text("다음")
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundStyle(.black)
-                        .padding(.vertical, 16)
-                        .frame(maxWidth: .infinity, idealHeight: 51)
-                        .background( Color.disabledNextButtonGray)
-                        .cornerRadius(6)
-                }
-                .padding(.horizontal, 20)
-                .opacity(viewModel.isPasswordValid() ? 0 : 1)
-            }
-            
-            Spacer()
-        }
-        .onTapGesture {
-            isPasswordFocused = false
-            isPassword2Focused = false
         }
     }
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep3PasswordView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct SignUpStep3PasswordView: View {
     @State private var viewModel = SignUpStep3ViewModel()
+    @FocusState private var isPasswordFocused: Bool
+    @FocusState private var isPassword2Focused: Bool
     
     var body: some View {
         VStack {
@@ -69,11 +71,17 @@ struct SignUpStep3PasswordView: View {
             Spacer()
                 .frame(height: 8)
             ZStack {
-                TextField("", text: $viewModel.password, prompt: Text("비밀번호 입력(8~32자리)")
+                SecureField("", text: $viewModel.password, prompt: Text("비밀번호 입력(8~32자리)")
                     .foregroundStyle(Color.promptLabelColor))
+                .focused($isPasswordFocused)
                 .padding(.vertical, 5)
                 .padding(.horizontal, 20)
                 .autocapitalization(.none)
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        isPasswordFocused = true
+                    }
+                }
                 
                 HStack {
                     Spacer()
@@ -93,15 +101,27 @@ struct SignUpStep3PasswordView: View {
             Spacer()
                 .frame(height: 5)
             Rectangle()
-                .foregroundStyle(false ? Color.emptyEmailWarnRed : .black)
+                .foregroundStyle(isPasswordFocused ? .black : viewModel.passwordValidator().isEmpty ? .emailCautionTextGray : Color.emptyEmailWarnRed)
                 .frame(height: 1)
                 .padding(.horizontal, 20)
             Spacer()
                 .frame(height: 5)
+            if !isPasswordFocused && !viewModel.passwordValidator().isEmpty {
+                Spacer()
+                    .frame(height: 5)
+                HStack {
+                    Text(viewModel.passwordValidator())
+                        .font(.system(size: 11, weight: .light))
+                        .foregroundStyle(Color.emptyEmailWarnRed)
+                        .padding(.horizontal, 20)
+                    Spacer()
+                }
+            }
             
             ZStack {
-                TextField("", text: $viewModel.password2, prompt: Text("비밀번호 재입력")
+                SecureField("", text: $viewModel.password2, prompt: Text("비밀번호 재입력")
                     .foregroundStyle(Color.promptLabelColor))
+                .focused($isPassword2Focused)
                 .padding(.vertical, 5)
                 .padding(.horizontal, 20)
                 .autocapitalization(.none)
@@ -124,9 +144,20 @@ struct SignUpStep3PasswordView: View {
             Spacer()
                 .frame(height: 5)
             Rectangle()
-                .foregroundStyle(false ? Color.emptyEmailWarnRed : .black)
+                .foregroundStyle(isPassword2Focused ? .black : isPasswordFocused || viewModel.isEqualPassword() ? Color.emailCautionTextGray : Color.emptyEmailWarnRed)
                 .frame(height: 1)
                 .padding(.horizontal, 20)
+            if !isPasswordFocused && !isPassword2Focused && !viewModel.isEqualPassword() {
+                Spacer()
+                    .frame(height: 5)
+                HStack {
+                    Text("입력한 비밀번호와 재입력한 비밀번호가 일치하지 않습니다.")
+                        .font(.system(size: 11, weight: .light))
+                        .foregroundStyle(Color.emptyEmailWarnRed)
+                        .padding(.horizontal, 20)
+                    Spacer()
+                }
+            }
             Spacer()
                 .frame(height: 24)
             
@@ -149,6 +180,10 @@ struct SignUpStep3PasswordView: View {
             .padding(.horizontal, 20)
             
             Spacer()
+        }
+        .onTapGesture {
+            isPasswordFocused = false
+            isPassword2Focused = false
         }
     }
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep4WelcomeView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep4WelcomeView.swift
@@ -48,9 +48,11 @@ struct SignUpStep4WelcomeView: View {
                 .padding(.bottom, 150)
             }
         }
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                CustomBackButton()
+            }
+        }
     }
-}
-
-#Preview {
-    SignUpStep4WelcomeView()
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep4WelcomeView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep4WelcomeView.swift
@@ -1,0 +1,20 @@
+//
+//  SignUpStep4WelcomeView.swift
+//  Wastory
+//
+//  Created by mujigae on 1/7/25.
+//
+
+import SwiftUI
+
+struct SignUpStep4WelcomeView: View {
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Text("환영합니다.")
+            }
+        }
+    }
+}
+

--- a/Wastory/Wastory/View/SignView/SignUpStep4WelcomeView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep4WelcomeView.swift
@@ -12,9 +12,45 @@ struct SignUpStep4WelcomeView: View {
     var body: some View {
         NavigationStack {
             VStack {
-                Text("환영합니다.")
+                Text("환영합니다!")
+                    .font(.system(size: 24))
+                    .padding(.top, 150)
+                Spacer()
+                    .frame(height: 12)
+                
+                Text("와스토리 계정 가입이 완료되었습니다.")
+                    .foregroundStyle(Color.promptLabelColor)
+                    .font(.system(size: 12))
+                Spacer()
+                    .frame(height: 3)
+                Text("와스토리를 즐겨 보세요!")
+                    .foregroundStyle(Color.promptLabelColor)
+                    .font(.system(size: 12))
+                Spacer()
+                    .frame(height: 30)
+                
+                Text(UserInfoRepository.shared.getUserID())
+                    .font(.system(size: 18, weight: .semibold))
+                
+                Spacer()
+                
+                Button {
+                } label: {
+                    Text("시작하기")
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundStyle(.black)
+                        .padding(.vertical, 16)
+                        .frame(maxWidth: .infinity, idealHeight: 51)
+                        .background(Color.kakaoYellow)
+                        .cornerRadius(6)
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 150)
             }
         }
     }
 }
 
+#Preview {
+    SignUpStep4WelcomeView()
+}

--- a/Wastory/Wastory/View/SignView/SignUpStep5UsernameView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep5UsernameView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct SignUpStep5UsernameView: View {
-    @Environment(\.dismiss) var dismiss
-    
     @State private var viewModel = SignUpStep5ViewModel()
     @Bindable  var userInfoRepository = UserInfoRepository.shared
     
@@ -133,15 +131,11 @@ struct SignUpStep5UsernameView: View {
             }
         }
         .navigationBarBackButtonHidden(true)
-        .navigationBarItems(
-            leading: Button(action: {
-                dismiss()
-            }) {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 20, weight: .light))
-                    .foregroundStyle(.black)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                CustomBackButton()
             }
-        )
+        }
     }
 }
 

--- a/Wastory/Wastory/View/SignView/SignUpStep5UsernameView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep5UsernameView.swift
@@ -1,5 +1,5 @@
 //
-//  SignUpView.swift
+//  SignUpStep5UsernameView.swift
 //  Wastory
 //
 //  Created by mujigae on 12/27/24.
@@ -7,10 +7,10 @@
 
 import SwiftUI
 
-struct SignUpView: View {
+struct SignUpStep5UsernameView: View {
     @Environment(\.dismiss) var dismiss
     
-    @State private var viewModel = SignUpViewModel()
+    @State private var viewModel = SignUpStep5ViewModel()
     @Bindable  var userInfoRepository = UserInfoRepository.shared
     
     var body: some View {

--- a/Wastory/Wastory/View/SignView/SignUpStep5UsernameView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep5UsernameView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SignUpStep5UsernameView: View {
     @State private var viewModel = SignUpStep5ViewModel()
-    @Bindable  var userInfoRepository = UserInfoRepository.shared
     
     var body: some View {
         NavigationStack {
@@ -35,7 +34,7 @@ struct SignUpStep5UsernameView: View {
                 
                 VStack(spacing: 5) {
                     HStack(spacing: 5) {
-                        Text("\(userInfoRepository.getUserID())")
+                        Text("\(UserInfoRepository.shared.getUserID())")
                             .font(.system(size: 14, weight: .bold))
                             .padding(.leading, 20)
                         Text("님,")

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -39,12 +39,12 @@ import Observation
     }
     
     func requestCode() {
-        if isEmailValid(email) {
+        if isEmailValid() {
             isCodeRequested = true
         }
     }
     
-    func isEmailValid(_ email: String) -> Bool {
+    func isEmailValid() -> Bool {
         let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
         return NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
     }
@@ -56,7 +56,7 @@ import Observation
         if email.isEmpty {
             return "와스토리 계정 이메일을 입력해 주세요."
         }
-        if isEmailValid(email) == false {
+        if isEmailValid() == false {
             return "와스토리 계정 이메일 형식이 올바르지 않습니다."
         }
         return ""

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -13,8 +13,8 @@ import Observation
     var code: String = ""
     
     private var isCodeRequested: Bool = false
-    private var emptyEmailRequested: Bool = false
-    private var invalidEmailRequested: Bool = false
+    private var touchedEmailScreen: Bool = false
+    private var tappedNextButton: Bool = false
     
     private let codeLength: Int = 8
     private var emptyCodeEntered: Bool = false
@@ -25,8 +25,6 @@ import Observation
         email = ""
         code = ""
         isCodeRequested = false
-        emptyEmailRequested = false
-        invalidEmailRequested = false
         emptyCodeEntered = false
         invalidCodeEntered = false
     }
@@ -35,39 +33,46 @@ import Observation
     func clearEmailTextField() {
         email = ""
     }
-    
     func isClearEmailButtonInactive() -> Bool {
         return email.isEmpty
     }
     
     func requestCode() {
-        if email.isEmpty {
-            invalidEmailRequested = false
-            emptyEmailRequested = true
-        }
-        else if isValidEmail(email) {
+        if isValidEmail(email) {
             isCodeRequested = true
-            emptyEmailRequested = false
-            invalidEmailRequested = false
         }
-        else {
-            emptyEmailRequested = false
-            invalidEmailRequested = true
-        }
-    }
-    
-    func isEmptyEmailRequested() -> Bool {
-        return emptyEmailRequested
-    }
-    
-    func isInvalidEmailRequested() -> Bool {
-        return invalidEmailRequested
     }
     
     func isValidEmail(_ email: String) -> Bool {
         let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
-        let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
-        return emailPredicate.evaluate(with: email)
+        return NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
+    }
+    
+    func emailValidator() -> String {
+        if tappedNextButton {
+            return "인증요청을 먼저 진행해 주세요."
+        }
+        if email.isEmpty {
+            return "와스토리 계정 이메일을 입력해 주세요."
+        }
+        if isValidEmail(email) == false {
+            return "와스토리 계정 이메일 형식이 올바르지 않습니다."
+        }
+        return ""
+    }
+    
+    func touchEmailScreen() {
+        touchedEmailScreen = true
+    }
+    func isEmailScreenTouched() -> Bool {
+        return touchedEmailScreen
+    }
+    
+    func tapNextButton() {
+        tappedNextButton = true
+    }
+    func untapNextButton() {
+        tappedNextButton = false
     }
     
     // MARK: Verification Code TextField

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -38,12 +38,12 @@ import Observation
     }
     
     func requestCode() {
-        if isValidEmail(email) {
+        if isEmailValid(email) {
             isCodeRequested = true
         }
     }
     
-    func isValidEmail(_ email: String) -> Bool {
+    func isEmailValid(_ email: String) -> Bool {
         let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
         return NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
     }
@@ -55,7 +55,7 @@ import Observation
         if email.isEmpty {
             return "와스토리 계정 이메일을 입력해 주세요."
         }
-        if isValidEmail(email) == false {
+        if isEmailValid(email) == false {
             return "와스토리 계정 이메일 형식이 올바르지 않습니다."
         }
         return ""
@@ -83,7 +83,6 @@ import Observation
     func clearCodeTextField() {
         code = ""
     }
-    
     func isClearCodeButtonInactive() -> Bool {
         return code.isEmpty
     }

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -17,16 +17,17 @@ import Observation
     private var tappedNextButton: Bool = false
     
     private let codeLength: Int = 8
-    private var emptyCodeEntered: Bool = false
-    private var invalidCodeEntered: Bool = false
+    private var touchedCodeScreen: Bool = false
+    
+    func getCodeLength() -> Int {
+        return codeLength
+    }
     
     func requestEmailReentry() {
         // 이메일 입력화면으로 되돌아가는 버튼
         email = ""
         code = ""
         isCodeRequested = false
-        emptyCodeEntered = false
-        invalidCodeEntered = false
     }
     
     // MARK: Email TextField
@@ -87,30 +88,29 @@ import Observation
         return code.isEmpty
     }
     
-    func isEmptyCodeEntered() -> Bool {
-        return emptyCodeEntered
-    }
-    
-    func isInvalidCodeEntered() -> Bool {
-        return invalidCodeEntered
-    }
-    
-    func checkCodeValidty(_ code: String) {
+    func codeValidator() -> String {
         if code.isEmpty {
-            invalidCodeEntered = false
+            return "이메일로 발송된 인증번호를 입력해 주세요."
         }
-        else {
-            emptyCodeEntered = false
-            invalidCodeEntered = !code.allSatisfy { $0.isNumber } || code.count < 8
+        if !code.allSatisfy({ $0.isNumber }) || code.count < codeLength {
+            return "인증번호 형식이 올바르지 않습니다."
         }
+        return ""
+    }
+    
+    func isCodeValid() -> Bool {
+        // 인증코드 유효성 검사 코드 필요
+        return true
     }
     
     func isVerificationSuccessful() -> Bool {
-        // 인증코드 유효성 검사 코드 필요
-        if code.isEmpty {
-            emptyCodeEntered = true
-            return false
-        }
-        return !code.isEmpty && !invalidCodeEntered
+        return !code.isEmpty && codeValidator().isEmpty && isCodeValid()
+    }
+    
+    func touchCodeScreen() {
+        touchedCodeScreen = true
+    }
+    func isCodeScreenTouched() -> Bool {
+        return touchedCodeScreen
     }
 }

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep3ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep3ViewModel.swift
@@ -67,7 +67,7 @@ import Observation
         return password2.isEmpty
     }
     
-    func isEqualPassword() -> Bool {
-        return password == password2
+    func isPasswordValid() -> Bool {
+        return passwordValidator().isEmpty && password == password2
     }
 }

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep3ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep3ViewModel.swift
@@ -16,17 +16,58 @@ import Observation
     func clearPasswordTextField() {
         password = ""
     }
-    
     func isClearPasswordButtonInactive() -> Bool {
         return password.isEmpty
+    }
+    
+    func passwordValidator() -> String {
+        // 1. 비밀번호가 비어 있는 경우
+        if password.isEmpty {
+            return "와스토리 계정 비밀번호를 입력해 주세요.(영문자/숫자/특수문자)"
+        }
+        
+        // 2. 비밀번호 길이가 범위를 벗어난 경우
+        if password.count < 8 || password.count > 32 {
+            return "비밀번호는 8~32자리(영문자/숫자/특수문자)로 입력할 수 있어요."
+        }
+        
+        // 3. 사용할 수 없는 문자가 포함된 경우
+        let forbiddenCharactersRegex = "[^A-Za-z\\d!@#$%^&*()_+\\-=\\[\\]{}|;:',.<>?/`~]"
+        if NSPredicate(format: "SELF MATCHES %@", forbiddenCharactersRegex).evaluate(with: password) {
+            return "영문자, 숫자, 특수문자만 비밀번호에 입력해 주세요."
+        }
+
+        // 4. 숫자만 사용한 경우
+        let numberOnlyRegex = "^[0-9]+$"
+        if NSPredicate(format: "SELF MATCHES %@", numberOnlyRegex).evaluate(with: password) {
+            return "영문자, 특수문자를 함께 입력해 주세요."
+        }
+
+        // 5. 영어만 사용한 경우
+        let lettersOnlyRegex = "^[A-Za-z]+$"
+        if NSPredicate(format: "SELF MATCHES %@", lettersOnlyRegex).evaluate(with: password) {
+            return "숫자, 특수문자를 함께 입력해 주세요."
+        }
+
+        // 6. 특수문자만 사용한 경우
+        let specialCharactersOnlyRegex = "^[!@#$%^&*()_+\\-=\\[\\]{}|;:',.<>?/`~]+$"
+        if NSPredicate(format: "SELF MATCHES %@", specialCharactersOnlyRegex).evaluate(with: password) {
+            return "영문자, 숫자를 함께 입력해 주세요."
+        }
+
+        // 7. 유효한 비밀번호
+        return ""
     }
     
     // MARK: 점검용 비밀번호 - password2
     func clearPassword2TextField() {
         password2 = ""
     }
-    
     func isClearPassword2ButtonInactive() -> Bool {
         return password2.isEmpty
+    }
+    
+    func isEqualPassword() -> Bool {
+        return password == password2
     }
 }

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep3ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep3ViewModel.swift
@@ -9,5 +9,24 @@ import SwiftUI
 import Observation
 
 @Observable final class SignUpStep3ViewModel {
-
+    var password: String = ""
+    var password2: String = ""
+    
+    // MARK: 비밀번호 - password
+    func clearPasswordTextField() {
+        password = ""
+    }
+    
+    func isClearPasswordButtonInactive() -> Bool {
+        return password.isEmpty
+    }
+    
+    // MARK: 점검용 비밀번호 - password2
+    func clearPassword2TextField() {
+        password2 = ""
+    }
+    
+    func isClearPassword2ButtonInactive() -> Bool {
+        return password2.isEmpty
+    }
 }

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep5ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep5ViewModel.swift
@@ -9,14 +9,12 @@ import SwiftUI
 import Observation
 
 @Observable final class SignUpStep5ViewModel {
-    private var userInfoRepository = UserInfoRepository.shared
-    
     var username = "example"
     var blogAddress = "example.waffle.com"
     var usernameAvailability = "사용할 수 없어요."
     
     func setUsername() {
-        userInfoRepository.setUsername(username: username)
+        UserInfoRepository.shared.setUsername(username: username)
     }
     
     func setBlogAddress() {
@@ -24,7 +22,7 @@ import Observation
     }
     
     func setUserInfo() {
-        userInfoRepository.setUserInfo()
+        UserInfoRepository.shared.setUserInfo()
     }
     
     func checkUsernameAvailability() {

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep5ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep5ViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  SignUpViewModel.swift
+//  SignUpStep5ViewModel.swift
 //  Wastory
 //
 //  Created by mujigae on 12/27/24.
@@ -8,7 +8,7 @@
 import SwiftUI
 import Observation
 
-@Observable final class SignUpViewModel {
+@Observable final class SignUpStep5ViewModel {
     private var userInfoRepository = UserInfoRepository.shared
     
     var username = "example"


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

-[O] 기능 추가 
-[] 기능 삭제
 -[O] 버그 수정
 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 

feature/add-signup-password-welcome-view -> main

### 변경 사항 

SignUpStep3EmailView, SignUpStep3ViewModel 구현 (유저 PW 결정 화면)
SignUpStep4WelcomeView 구현 (환영인사 화면)
SignUpView, SignUpViewModel -> SignUpStep5UsernameView, SignUpStep5ViewModel 로 이름 변경
커스텀 백버튼 추가와 적용
각종 버그 수정

### 추후 보완 사항

서버 연결을 위한 네트워크 파일들을 생성할 예정
서버 연결 후 Step5와 회원가입 화면 또는 로그인 화면을 연결
[ 시나리오: 회원가입 시 ID, PW를 DB에 POST (블로그 주소가 없는 상태) -> Step4에서 시작하기 버튼 or 로그인 화면에서 로그인 or 자동로그인 시 DB에서 GET -> 불러온 정보에서 블로그 주소가 없을 경우 Step5로 가서 블로그 주소 생성 후 DB에 PATCH -> 불러온 정보에서 블로그 주소가 있거나 Step5에서 블로그 주소를 설정했을 경우 MainTabView로 이동 ]

참고 영상

https://github.com/user-attachments/assets/c215d7ef-a1f6-4eee-bb58-96b9acc4c131


제가 @FocusState 기능을 구현하려다 EmailView에서 왠지는 모르겠는데 사용만 하면 시뮬레이터가 멈춰서 해결해 보다가 실패했습니다. 그래서 EmailView textField에서 더 디테일한 뷰 변환은 포기해야 할 것 같습니다. 제가 이거 때문에 시간을 너무 많이 써서 1/7에 스웨거 링크 받으면 보면서 네트워크 연결까지 마무리 해볼 예정입니다.