### PR TITLE
Hotfix/Fix: FeedCell blogNameText to Button

### DIFF
--- a/Wastory/Wastory/View/FeedView/FeedCell.swift
+++ b/Wastory/Wastory/View/FeedView/FeedCell.swift
@@ -63,21 +63,24 @@ struct FeedCell: View {
                 }
                 
                 //MARK: posted blog info
-                HStack(alignment: .center, spacing: 9) {
-                    //blog image
-                    Image(systemName: "questionmark.app.dashed")
-                        .resizable()
-                        .frame(width: 20, height: 20)
-                        .background(Color.secondaryLabelColor.opacity(0.3))
-                        .clipped()
-                        .cornerRadius(5)
-                    
-                    //blog name
-                    Text("Blog name")
-                        .font(.system(size: 14, weight: .light))
-                        .foregroundStyle(Color.secondaryLabelColor)
+                Button(action: {
+                    // Blog View로 이동
+                }) {
+                    HStack(alignment: .center, spacing: 9) {
+                        //blog image
+                        Image(systemName: "questionmark.app.dashed")
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                            .background(Color.secondaryLabelColor.opacity(0.3))
+                            .clipped()
+                            .cornerRadius(5)
+                        
+                        //blog name
+                        Text("Blog name")
+                            .font(.system(size: 14, weight: .light))
+                            .foregroundStyle(Color.secondaryLabelColor)
+                    }
                 }
-                
             }
             .padding(.trailing, 20)
             


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[O] 기능 추가
 -[] 기능 삭제
 -[] 버그 수정
 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Hotfix/fix-FeedCell-blogName-to-Button -> main

### 변경 사항 
FeedCell의 blogName Text를 Button으로 수정하였습니다.

### 추후 보완 사항

- API와 연결
- 셀 터치 시 글View로 이동
- 블로그 버튼 터치 시 블로그  View로 이동