### PR TITLE
Feat: Add Blog Sheet Button

### DIFF
--- a/Wastory/Wastory/Repository/UserInfoRepository.swift
+++ b/Wastory/Wastory/Repository/UserInfoRepository.swift
@@ -80,6 +80,7 @@ final class UserInfoRepository {
         do {
             let response = try await NetworkRepository.shared.getMyBlog()
             addressName = response.addressName
+            blogName = response.blogName
             blogID = response.blogID
         } catch {
             print("Error: \(error.localizedDescription)")

--- a/Wastory/Wastory/View/BlogSheet.swift
+++ b/Wastory/Wastory/View/BlogSheet.swift
@@ -1,0 +1,98 @@
+//
+//  BlogSheet.swift
+//  Wastory
+//
+//  Created by mujigae on 1/18/25.
+//
+
+import SwiftUI
+
+struct BlogSheet: View {
+    @Bindable var mainTabViewModel: MainTabViewModel
+    
+    var body: some View {
+        ZStack {
+            //MARK: Background Dimming
+            (mainTabViewModel.isBlogSheetPresent ? Color.sheetOuterBackgroundColor : Color.clear)
+                .frame(maxHeight: .infinity)
+                .frame(maxWidth: .infinity)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    mainTabViewModel.toggleIsBlogSheetPresent()
+                }
+            
+            //MARK: NotificationTypeSheet List
+            VStack {
+                Spacer()
+                if mainTabViewModel.isBlogSheetPresent {
+                    ZStack {
+                        VStack(spacing: 0) {
+                            Spacer()
+                                .frame(height: 30)
+                            
+                            HStack {
+                                Image(systemName: "questionmark.text.page.fill")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: 50, height: 50)
+                                    .clipShape(Circle())
+                                    .padding(.leading, 20)
+                                Spacer()
+                                    .frame(width: 20)
+                                //Text(UserInfoRepository.shared.getUserName())
+                                Text(UserInfoRepository.shared.getBlogName())   // 아직 username API가 없어 임시로 대체
+                                    .font(.system(size: 17, weight: .semibold))
+                                Spacer()
+                                Button {
+                                    // TODO: 설정 화면 진입 버튼
+                                } label: {
+                                    Image(systemName: "gearshape")
+                                        .font(.system(size: 26))
+                                        .foregroundStyle(Color.settingGearGray)
+                                }
+                                .padding(.trailing, 20)
+                            }
+                            Spacer()
+                                .frame(height: 20)
+                            
+                            Divider()
+                                .foregroundStyle(Color.secondaryLabelColor)
+                            Spacer()
+                                .frame(height: 20)
+                            
+                            HStack {
+                                Image(systemName: "questionmark.text.page.fill")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: 40, height: 40)
+                                    .clipShape(
+                                        RoundedRectangle(cornerRadius: 12)
+                                    )
+                                    .padding(.leading, 25)
+                                Spacer()
+                                    .frame(width: 20)
+                                Text(UserInfoRepository.shared.getBlogName())
+                                    .font(.system(size: 15, weight: .regular))
+                                Spacer()
+                            }
+                            
+                            Spacer()
+                                .frame(height: 50)
+                        }
+                        .background(Color.white)
+                        .cornerRadius(20)
+                        
+                    }
+                    .background(Color.clear)
+                    .transition(.move(edge: .bottom)) // 아래에서 올라오는 애니메이션
+                    .animation(.easeInOut, value: mainTabViewModel.isBlogSheetPresent)
+                }
+            }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+extension Color {
+    static let settingGearGray: Color = .init(red: 77 / 255, green: 77 / 255, blue: 77 / 255)  // 블로그 시트 세팅 버튼 회색
+}

--- a/Wastory/Wastory/View/FeedView/FeedView.swift
+++ b/Wastory/Wastory/View/FeedView/FeedView.swift
@@ -100,15 +100,6 @@ struct FeedView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(.automatic, for: .navigationBar)
         .toolbarBackground(Color.white, for: .navigationBar)
-        .toolbar{
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button{
-                    
-                } label: {
-                    Text(Image(systemName: "magnifyingglass"))
-                }
-            } // navbar 사이즈 설정을 위한 임의 버튼입니다.
-        }
                 
         
     }

--- a/Wastory/Wastory/View/HomeView/HomeView.swift
+++ b/Wastory/Wastory/View/HomeView/HomeView.swift
@@ -8,9 +8,8 @@
 import SwiftUI
 
 struct HomeView: View {
-    
+    @Bindable var mainTabViewModel: MainTabViewModel
     @State var viewModel = HomeViewModel()
-    
     
     var body: some View {
         ScrollView {
@@ -80,7 +79,7 @@ struct HomeView: View {
             
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    //
+                    mainTabViewModel.toggleIsBlogSheetPresent()
                 } label: {
                     ZStack {
                         Circle()
@@ -113,10 +112,11 @@ struct HomeView: View {
     
 }
 
-
+/*
 #Preview {
     HomeView()
 }
+*/
 
 struct MainWCircleUnit: View {
     var body: some View {

--- a/Wastory/Wastory/View/HomeView/HomeView.swift
+++ b/Wastory/Wastory/View/HomeView/HomeView.swift
@@ -68,43 +68,6 @@ struct HomeView: View {
                 }
                 .padding(.horizontal, 5)
             }
-            
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button{
-                    
-                } label: {
-                    Text(Image(systemName: "magnifyingglass"))
-                }
-            }
-            
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    mainTabViewModel.toggleIsBlogSheetPresent()
-                } label: {
-                    ZStack {
-                        Circle()
-                            .fill(Color.mainWBackgroundGray)
-                            .frame(width: 36, height: 36)
-                        VStack(spacing: 2) {
-                            HStack(spacing: 4) {
-                                MainWCircleUnit()
-                                MainWCircleUnit()
-                                MainWCircleUnit()
-                            }
-                            HStack(spacing: 4) {
-                                MainWCircleUnit()
-                                MainWCircleUnit()
-                                MainWCircleUnit()
-                            }
-                            HStack(spacing: 4) {
-                                MainWCircleUnit()
-                                MainWCircleUnit()
-                            }
-                        }
-                    }
-                }
-                .padding(.trailing, 10)
-            }
         } //toolbar
         
     }

--- a/Wastory/Wastory/View/HomeView/HomeView.swift
+++ b/Wastory/Wastory/View/HomeView/HomeView.swift
@@ -77,6 +77,35 @@ struct HomeView: View {
                     Text(Image(systemName: "magnifyingglass"))
                 }
             }
+            
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    //
+                } label: {
+                    ZStack {
+                        Circle()
+                            .fill(Color.mainWBackgroundGray)
+                            .frame(width: 36, height: 36)
+                        VStack(spacing: 2) {
+                            HStack(spacing: 4) {
+                                MainWCircleUnit()
+                                MainWCircleUnit()
+                                MainWCircleUnit()
+                            }
+                            HStack(spacing: 4) {
+                                MainWCircleUnit()
+                                MainWCircleUnit()
+                                MainWCircleUnit()
+                            }
+                            HStack(spacing: 4) {
+                                MainWCircleUnit()
+                                MainWCircleUnit()
+                            }
+                        }
+                    }
+                }
+                .padding(.trailing, 10)
+            }
         } //toolbar
         
     }
@@ -87,4 +116,17 @@ struct HomeView: View {
 
 #Preview {
     HomeView()
+}
+
+struct MainWCircleUnit: View {
+    var body: some View {
+        Circle()
+            .fill(Color.mainWCircleGray)
+            .frame(width: 4.2, height: 4.2)
+    }
+}
+
+extension Color {
+    static let mainWBackgroundGray: Color = .init(red: 208 / 255, green: 208 / 255, blue: 208 / 255)  // 메인 네비게이션 바 W 버튼 배경색
+    static let mainWCircleGray: Color = .init(red: 245 / 255, green: 245 / 255, blue: 245 / 255)  // 메인 네비게이션 바 W 버튼 유닛 색
 }

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -15,7 +15,7 @@ struct MainTabView: View {
         ZStack {
             TabView(selection: $mainTabViewModel.selectedTab) {
                 NavigationStack {
-                    HomeView()
+                    HomeView(mainTabViewModel: mainTabViewModel)
                 }
                 .tabItem {
                     Text("홈")
@@ -74,6 +74,9 @@ struct MainTabView: View {
                     mainTabViewModel.setSelectedTab(to: oldValue)
                 }
             }
+            
+            // MARK: BlogSheet
+            BlogSheet(mainTabViewModel: mainTabViewModel)
             
             // MARK: NotificationTypeSheet
             NotificationTypeSheet(viewModel: notificationViewModel, mainTabViewModel: mainTabViewModel)

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -133,7 +133,6 @@ extension View {
                             }
                         }
                     }
-                    .padding(.trailing, 10)
                 }
             }
     }

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -66,6 +66,7 @@ struct MainTabView: View {
                     Text("내블로그")
                 }
                 .tag(TabType.myBlog)
+                .mainTabToolbarConfigurations()
             }
             .tint(.black)
             .onChange(of: mainTabViewModel.selectedTab) { oldValue, newValue in

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -60,10 +60,10 @@ struct MainTabView: View {
                 
                 NavigationStack {
                     //MyBlogView로 추후 연결
+                    MyBlogView()
                 }
                 .tabItem {
                     Text("내블로그")
-                    MyBlogView()
                 }
                 .tag(TabType.myBlog)
             }

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -16,22 +16,22 @@ struct MainTabView: View {
             TabView(selection: $mainTabViewModel.selectedTab) {
                 NavigationStack {
                     HomeView(mainTabViewModel: mainTabViewModel)
+                        .mainTabToolbarConfigurations(with: $mainTabViewModel)
                 }
                 .tabItem {
                     Text("홈")
                 }
                 .tag(TabType.home)
-                .mainTabToolbarConfigurations()
                 
                 
                 NavigationStack {
                     FeedView()
+                        .mainTabToolbarConfigurations(with: $mainTabViewModel)
                 }
                 .tabItem {
                     Text("피드")
                 }
                 .tag(TabType.feed)
-                .mainTabToolbarConfigurations()
                 
                 
                 Color.clear
@@ -39,7 +39,7 @@ struct MainTabView: View {
                         Text("글쓰기")
                     }
                     .tag(TabType.write)
-                    .mainTabToolbarConfigurations()
+                    .mainTabToolbarConfigurations(with: $mainTabViewModel)
                     .fullScreenCover(isPresented: $mainTabViewModel.isPostingViewPresent) {
                         NavigationStack {
                             //MARK: PostingView
@@ -50,22 +50,21 @@ struct MainTabView: View {
                 
                 NavigationStack {
                     NotificationView(viewModel: notificationViewModel, mainTabViewModel: mainTabViewModel)
+                        .mainTabToolbarConfigurations(with: $mainTabViewModel)
                 }
                 .tabItem {
                     Text("알림")
                 }
                 .tag(TabType.notification)
-                .mainTabToolbarConfigurations()
                 
                 
                 NavigationStack {
-                    // statView
+                    //MyBlogView로 추후 연결
                 }
                 .tabItem {
-                    Text("stat")
+                    Text("내블로그")
                 }
-                .tag(TabType.stat)
-                .mainTabToolbarConfigurations()
+                .tag(TabType.myBlog)
             }
             .tint(.black)
             .onChange(of: mainTabViewModel.selectedTab) { oldValue, newValue in
@@ -92,11 +91,49 @@ struct MainTabView: View {
 }
 
 extension View {
-    func mainTabToolbarConfigurations() -> some View {
+    func mainTabToolbarConfigurations(with mainTabViewModel: Binding<MainTabViewModel>) -> some View {
         self
             .toolbarBackground(.white, for: .tabBar)
             .toolbarBackground(.visible, for: .tabBar)
             .toolbarBackground(Color.white, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        // TODO: Search API
+                    } label: {
+                        Image(systemName: "magnifyingglass")
+                    }
+                }
+                
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        mainTabViewModel.wrappedValue.toggleIsBlogSheetPresent()
+                    } label: {
+                        ZStack {
+                            Circle()
+                                .fill(Color.mainWBackgroundGray)
+                                .frame(width: 36, height: 36)
+                            VStack(spacing: 2) {
+                                HStack(spacing: 4) {
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                }
+                                HStack(spacing: 4) {
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                }
+                                HStack(spacing: 4) {
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                }
+                            }
+                        }
+                    }
+                    .padding(.trailing, 10)
+                }
+            }
     }
 }
 
@@ -107,6 +144,6 @@ enum TabType: String {
     case feed
     case write
     case notification
-    case stat
+    case myBlog
 }
 

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -63,6 +63,7 @@ struct MainTabView: View {
                 }
                 .tabItem {
                     Text("내블로그")
+                    MyBlogView()
                 }
                 .tag(TabType.myBlog)
             }

--- a/Wastory/Wastory/View/NotificationView/NotificationView.swift
+++ b/Wastory/Wastory/View/NotificationView/NotificationView.swift
@@ -70,15 +70,6 @@ struct NotificationView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(.automatic, for: .navigationBar)
         .toolbarBackground(Color.white, for: .navigationBar)
-        .toolbar{
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button{
-                    
-                } label: {
-                    Text(Image(systemName: "magnifyingglass"))
-                }
-            } // navbar 사이즈 설정을 위한 임의 버튼입니다.
-        }
     }
     
     

--- a/Wastory/Wastory/ViewModel/MainTabViewModel.swift
+++ b/Wastory/Wastory/ViewModel/MainTabViewModel.swift
@@ -11,6 +11,8 @@ import Observation
 @Observable final class MainTabViewModel {
     var selectedTab: TabType = .home
     
+    var isBlogSheetPresent: Bool = false
+    
     var isPostingViewPresent: Bool = false
     
     var isNotificationTypeSheetPresent: Bool = false
@@ -18,6 +20,13 @@ import Observation
     //MARK: selectedTab
     func setSelectedTab(to tab: TabType) {
         selectedTab = tab
+    }
+    
+    //MARK: isBlogSheetPresent
+    func toggleIsBlogSheetPresent() {
+        withAnimation(.easeInOut) {
+            isBlogSheetPresent.toggle()
+        }
     }
     
     //MARK: isNotificationTypeSheetPresent


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

-[O] 기능 추가 
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 

feature/add-log-out -> main

### 변경 사항 

기존 화면들에 있던 돋보기 trailing button 삭제
메인 탭에서 공통 네비게이션 바 속성으로 trailing button 추가
버튼 누를 시 블로그 시트가 나오도록 기능 추가

### 추후 보완 사항

설정 화면으로 이동하는 기능 필요
개인이 블로그를 여러 개 가질 경우 블로그를 전환할 수 있어야 하나 해당 기능은 잠정 미구현
버튼 아이콘을 W custom으로 만들어 놓았으나 대표 이미지를 가져오는 기능 필요 및 기본 이미지 (W 모앙) 생성 필요
PR #40 에서 MainTabView를 수정하여 일단 필요한 부분만 수정해 놓긴 했으나  머지 충돌이 발생할 가능성 있음