### PR TITLE
Feat: Check email duplication

### DIFF
--- a/Wastory/Wastory/Repository/NetworkRepository.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository.swift
@@ -31,6 +31,30 @@ final class NetworkRepository {
     }
     
     // MARK: - User
+    func postEmailExists(email: String) async throws -> Bool {
+        let requestBody = [
+            "email": email
+        ]
+        var urlRequest = try URLRequest(
+            url: NetworkRouter.postEmailExists.url,
+            method: NetworkRouter.postEmailExists.method,
+            headers: NetworkRouter.postEmailExists.headers
+        )
+        urlRequest.httpBody = try JSONEncoder().encode(requestBody)
+        
+        logRequest(urlRequest, body: requestBody)
+        
+        let response = try await AF.request(urlRequest)
+            .validate()
+            .serializingString()
+            .value
+            
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        // response: {"verification":???}
+        return response[16..<response.count - 1] == "true"
+    }
+    
     func postSignUp(userID: String, userPW: String) async throws {
         let requestBody = [
             "email": userID,

--- a/Wastory/Wastory/Repository/NetworkRouter.swift
+++ b/Wastory/Wastory/Repository/NetworkRouter.swift
@@ -10,6 +10,7 @@ import Alamofire
 
 enum NetworkRouter {
     // MARK: User
+    case postEmailExists
     case postSignUp
     case postSignIn
     case deleteMe
@@ -36,6 +37,7 @@ enum NetworkRouter {
     var path: String {
         switch self {
         // MARK: User
+        case .postEmailExists: "/users/email-exists"
         case .postSignUp: "/users/signup"
         case .postSignIn: "/users/signin"
         case .deleteMe: "/users/me"
@@ -58,6 +60,8 @@ enum NetworkRouter {
     var method: HTTPMethod {
         switch self {
         // MARK: User
+        case .postEmailExists:
+            return .post
         case .postSignUp:
             return .post
         case .postSignIn:
@@ -90,6 +94,8 @@ enum NetworkRouter {
     var headers: HTTPHeaders? {
         switch self {
         // MARK: User
+        case .postEmailExists:
+            return ["Content-Type": "application/json"]
         case .postSignUp:
             return ["Content-Type": "application/json"]
         case .postSignIn:

--- a/Wastory/Wastory/View/SignView/SignInView.swift
+++ b/Wastory/Wastory/View/SignView/SignInView.swift
@@ -170,6 +170,7 @@ struct SignInView: View {
                     Spacer()
                 }
             }
+            .navigationBarBackButtonHidden()
         }
     }
 }

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SignUpStep2EmailView: View {
     @State private var viewModel = SignUpStep2ViewModel()
-    @State private var showUnavailableEmailBox = false
     @State private var showRerequestEmailBox = false
     
     @FocusState private var isEmailFocused: Bool
@@ -141,10 +140,12 @@ struct SignUpStep2EmailView: View {
                                 .opacity(viewModel.isClearEmailButtonInactive() ? 0 : 1)
                                 
                                 Button {
-                                    isEmailFocused = false
-                                    viewModel.touchEmailScreen()
-                                    viewModel.untapNextButton()
-                                    viewModel.requestCode()
+                                    Task {
+                                        isEmailFocused = false
+                                        viewModel.touchEmailScreen()
+                                        viewModel.untapNextButton()
+                                        await viewModel.requestCode()
+                                    }
                                 } label: {
                                     Text("인증요청")
                                         .font(.system(size: 14, weight: .regular))
@@ -276,26 +277,25 @@ struct SignUpStep2EmailView: View {
                     Spacer()
                 }
                 
-                if showUnavailableEmailBox {
+                if viewModel.emailExists {
                     Color.black.opacity(0.5)
                         .ignoresSafeArea()
-                        .onTapGesture {
-                            showUnavailableEmailBox = false
-                        }
                     
                     Rectangle()
                         .foregroundStyle(.white)
-                        .frame(height: 300)
+                        .frame(height: 240)
                         .cornerRadius(12)
                         .padding(.horizontal, 20)
                     
-                    VStack(spacing: 12) {
+                    VStack(spacing: 0) {
                         HStack {
                             Text("이미 와스토리 계정에 사용 중인 이메일입니다.")
-                                .font(.system(size: 15, weight: .semibold))
+                                .font(.system(size: 17, weight: .semibold))
                                 .padding(.horizontal, 40)
                             Spacer()
                         }
+                        Spacer()
+                            .frame(height: 12)
                         HStack {
                             Text("등록된 와스토리 계정으로 로그인하거나, 다른 이메일을 입력해 주세요.")
                                 .font(.system(size: 14))
@@ -303,26 +303,29 @@ struct SignUpStep2EmailView: View {
                                 .padding(.horizontal, 40)
                             Spacer()
                         }
+                        Spacer()
+                            .frame(height: 24)
                         
-                        Button {
-                            showUnavailableEmailBox = false
-                        } label: {
+                        NavigationLink(destination: SignInView()) {
                             Text("로그인")
                                 .font(.system(size: 16, weight: .regular))
                                 .foregroundStyle(.black)
-                                .padding(.vertical, 16)
+                                .padding(.vertical, 12)
                                 .frame(maxWidth: .infinity, idealHeight: 45)
                                 .background(Color.kakaoYellow)
                                 .cornerRadius(6)
                         }
                         .padding(.horizontal, 40)
+                        Spacer()
+                            .frame(height: 12)
                         Button {
-                            showUnavailableEmailBox = false
+                            viewModel.toggleEmailExists()
+                            viewModel.email = ""
                         } label: {
                             Text("다시 입력")
                                 .font(.system(size: 16, weight: .regular))
                                 .foregroundStyle(.black)
-                                .padding(.vertical, 16)
+                                .padding(.vertical, 12)
                                 .frame(maxWidth: .infinity, idealHeight: 45)
                                 .background(Color.disabledNextButtonGray)
                                 .cornerRadius(6)

--- a/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
+++ b/Wastory/Wastory/ViewModel/SignViewModel/SignUpStep2ViewModel.swift
@@ -10,6 +10,7 @@ import Observation
 
 @Observable final class SignUpStep2ViewModel {
     var email: String = ""
+    var emailExists: Bool = false
     var code: String = ""
     
     private var isCodeRequested: Bool = false
@@ -38,10 +39,23 @@ import Observation
         return email.isEmpty
     }
     
-    func requestCode() {
+    func requestCode() async {
         if isEmailValid() {
+            do {
+                emailExists = try await NetworkRepository.shared.postEmailExists(email: email)
+            }
+            catch {
+                print("Error: \(error.localizedDescription)")
+            }
+            if emailExists { return }
+            
+            // TODO: 인증 코드 API 연결 필요
             isCodeRequested = true
         }
+    }
+    
+    func toggleEmailExists() {
+        emailExists.toggle()
     }
     
     func isEmailValid() -> Bool {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

-[O] 기능 추가 
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 

feature/check-email-duplication -> main

### 변경 사항 

회원가입 시 이미 존재하는 이메일(아이디)을 입력했을 경우를 위한 UI 및 기능 추가

### 추후 보완 사항

User API 남은 기능 현황:
1. 이메일 이용한 인증 코드
2. 소셜 로그인
3. 회원 정보 변경 (다음으로 작업할 대상 - 지금 보니까 티스토리는 카카오 계정 기반이라 이게 없어서 설정 뷰에서 따로 UI를 만들어야 할 것 같아요.)
3은 어렵지 않을 듯하고 1, 2만 추후 알아 보고 추가하면 여기는 완전히 마무리 될 것 같습니다.

참고 영상

https://github.com/user-attachments/assets/8fd8aaa8-a2f1-4290-b168-9986a2a42bf2

