### PR TITLE
Feature/connect blog view

### DIFF
--- a/Wastory/Wastory.xcodeproj/project.pbxproj
+++ b/Wastory/Wastory.xcodeproj/project.pbxproj
@@ -269,7 +269,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Wastory/Preview Content\"";
-				DEVELOPMENT_TEAM = 9ALDQUK5MU;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -298,7 +298,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Wastory/Preview Content\"";
-				DEVELOPMENT_TEAM = 9ALDQUK5MU;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Wastory/Wastory.xcodeproj/project.pbxproj
+++ b/Wastory/Wastory.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Wastory/Preview Content\"";
+				DEVELOPMENT_TEAM = 9ALDQUK5MU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -297,6 +298,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Wastory/Preview Content\"";
+				DEVELOPMENT_TEAM = 9ALDQUK5MU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Wastory/Wastory/Model/Blog.swift
+++ b/Wastory/Wastory/Model/Blog.swift
@@ -30,7 +30,7 @@ struct Blog: Codable, Identifiable, Hashable {
 import SwiftUI
 extension View {
     func tempBlog() -> Blog {
-        Blog.init(id: 0, blogName: "블로그 이름", addressName: "WaSans", description: "블로그 설명어어어어엉엉", userID: 0)
+        Blog.init(id: 5, blogName: "블로그 이름", addressName: "WaSans", description: "블로그 설명어어어어엉엉", userID: 0)
     }
 }
 

--- a/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
@@ -46,6 +46,36 @@ extension NetworkRepository {
 //            .serializingString().value
 //    }
     
+    // MARK: - Article
+    func getTopArticlesInBlog(blogID: Int, sortBy: String) async throws -> [Post] {
+        let urlRequest = try URLRequest(
+            url: NetworkRouter.getTopArticlesInBlog(blogID: blogID, sortBy: sortBy).url,
+            method: NetworkRouter.getTopArticlesInBlog(blogID: blogID, sortBy: sortBy).method,
+            headers: NetworkRouter.getTopArticlesInBlog(blogID: blogID, sortBy: sortBy).headers
+        )
+        
+        logRequest(urlRequest)
+        
+        // ISO8601DateFormatter로 날짜 처리
+        let decoder = JSONDecoder()
+        
+        // DateFormatter를 사용하여 ISO8601 형식을 맞추기
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(PostListDto.self, decoder: decoder)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response.articles
+    }
+    
     // MARK: - Comment
     func postComment(postID: Int, content: String, parentID: Int?, isSecret: Bool) async throws {
         var requestBody = [String: String]()

--- a/Wastory/Wastory/Repository/NetworkRouter.swift
+++ b/Wastory/Wastory/Repository/NetworkRouter.swift
@@ -21,9 +21,11 @@ enum NetworkRouter {
     case getMyBlog
     case getBlog(blogAddress: String)
     
-    // MARK: Blog
+    // MARK: Article
     case postArticle
     case getArticlesInBlog(blogID: Int)
+    case getTopArticlesInBlog(blogID: Int, sortBy: String)
+    
     
     //MARK: Comment
     case postComment(postID: Int)
@@ -52,6 +54,7 @@ enum NetworkRouter {
         // MARK: Article
         case .postArticle: "/articles/create"
         case let .getArticlesInBlog(blogID): "/articles/blogs/\(blogID)"
+        case let .getTopArticlesInBlog(blogID, sortBy): "/articles/blogs/\(blogID)/sort_by/\(sortBy)"
             
         // MARK: Comment
         case let .postComment(postID): "/comments/article/\(postID)"
@@ -86,7 +89,9 @@ enum NetworkRouter {
             return .post
         case .getArticlesInBlog:
             return .get
-        
+        case .getTopArticlesInBlog:
+            return .get
+            
         // MARK: Comment
         case .postComment:
             return .post
@@ -121,6 +126,8 @@ enum NetworkRouter {
         case .postArticle:
             return ["Content-Type": "application/json"]
         case .getArticlesInBlog:
+            return ["Content-Type": "application/json"]
+        case .getTopArticlesInBlog:
             return ["Content-Type": "application/json"]
             
             

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogHeaderView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogHeaderView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct BlogHeaderView: View {
+    let blog: Blog
+    
     var body: some View {
         ZStack{
             Color.loadingCoralRed// 임시 배경 TODO: Blog.mainImage의 대표 색을 추출해 그라데이션으로 표현
@@ -16,7 +18,7 @@ struct BlogHeaderView: View {
                 Spacer()
                     .frame(height: 120)
                 
-                Text("블로그 제목")
+                Text(blog.blogName)
                     .font(.system(size: 30, weight: .bold))
                     .foregroundStyle(Color.primaryDarkModeLabelColor)
                 
@@ -38,7 +40,7 @@ struct BlogHeaderView: View {
                 Spacer()
                     .frame(height: 17)
                 
-                Text("블로그 설명 \n블로그에 대한 긴 설명 \n\n더더 더 긴 블로그에 대한 설명더더 더 긴 블로그에 대한 설명더더 더 긴 블로그에 대한 설명")
+                Text(blog.description)
                     .font(.system(size: 15, weight: .medium))
                     .foregroundStyle(Color.secondaryDarkModeLabelColor)
                     .lineSpacing(4)
@@ -101,8 +103,4 @@ struct BlogHeaderView: View {
             .padding(.horizontal, 20)
         }
     }
-}
-
-#Preview {
-    BlogHeaderView()
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListCell.swift
@@ -92,7 +92,7 @@ struct BlogPostListCell: View {
         
         .background(Color.white)
         .overlay {
-            contentViewModel.navigateToPostViewButton(tempPost())
+            contentViewModel.navigateToPostViewButton(post)
         }
     }
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListCell.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct BlogPostListCell: View {
+    let post: Post
     
     @Environment(\.contentViewModel) var contentViewModel
     @Environment(\.blogViewModel) var viewModel
@@ -16,7 +17,7 @@ struct BlogPostListCell: View {
         VStack(spacing: 0) {
             HStack(alignment: .top, spacing: 0) {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("제목제목제목제목제목제목제목제목제목제목제목제목제목제목")
+                    Text(post.title)
                         .font(.system(size: 18, weight: .light))
                         .foregroundStyle(Color.primaryLabelColor)
                         .lineLimit(2)
@@ -24,7 +25,7 @@ struct BlogPostListCell: View {
                     Spacer()
                         .frame(height: 5)
                     
-                    Text("내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용")
+                    Text(post.description ?? "")
                         .font(.system(size: 16, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)
                         .lineLimit(2)
@@ -36,7 +37,7 @@ struct BlogPostListCell: View {
                         HStack(alignment: .center, spacing: 3) {
                             Image(systemName: "heart")
                             
-                            Text("50")
+                            Text("\(post.likeCount)")
                         }
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)
@@ -48,7 +49,7 @@ struct BlogPostListCell: View {
                         HStack(alignment: .center, spacing: 3) {
                             Image(systemName: "ellipsis.bubble")
                             
-                            Text("5")
+                            Text("\(post.commentCount)")
                         }
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)
@@ -96,7 +97,3 @@ struct BlogPostListCell: View {
     }
 }
 
-
-#Preview {
-    BlogPostListCell()
-}

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
@@ -39,6 +39,13 @@ struct BlogPostListView: View {
             LazyVStack(spacing: 0) {
                 ForEach(Array(viewModel.blogPosts.enumerated()), id: \.offset) { index, post in
                     BlogPostListCell(post: post)
+                        .onAppear {
+                            if index == viewModel.blogPosts.count - 1 {
+                                Task {
+                                    await viewModel.getPostsInBlog()
+                                }
+                            }
+                        }
                 }
             }
         } //VStack

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
@@ -37,7 +37,7 @@ struct BlogPostListView: View {
                 .frame(height: 5)
             
             LazyVStack(spacing: 0) {
-                ForEach(Array(viewModel.blogPostListItems.enumerated()), id: \.offset) { index, item in
+                ForEach(Array(viewModel.blogPosts.enumerated()), id: \.offset) { index, item in
                     BlogPostListCell()
                 }
             }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
@@ -37,8 +37,8 @@ struct BlogPostListView: View {
                 .frame(height: 5)
             
             LazyVStack(spacing: 0) {
-                ForEach(Array(viewModel.blogPosts.enumerated()), id: \.offset) { index, item in
-                    BlogPostListCell()
+                ForEach(Array(viewModel.blogPosts.enumerated()), id: \.offset) { index, post in
+                    BlogPostListCell(post: post)
                 }
             }
         } //VStack

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -42,6 +42,17 @@ struct BlogView: View {
                     
                 } //VStack
             } //ScrollView
+            // MARK: refreshing
+            .refreshable {
+                print("refresh")
+                viewModel.resetPage()
+                Task {
+                    await viewModel.getPostsInBlog()
+                }
+                Task {
+                    await viewModel.getPopularBlogPosts()
+                }
+            }
             
             
             //MARK: CategorySheet

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -105,6 +105,15 @@ struct BlogView: View {
             .ignoresSafeArea()
             
         } //ZStack
+        .onAppear {
+            viewModel.initBlogID(blog.id)
+            Task {
+                await viewModel.getPostsInBlog()
+            }
+            Task {
+                await viewModel.getPopularBlogPosts()
+            }
+        }
         .environment(\.blogViewModel, viewModel)
         .ignoresSafeArea(edges: .all)
         // MARK: NavBar

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -20,7 +20,7 @@ struct BlogView: View {
             ScrollView(.vertical) {
                 VStack(spacing: 0) {
                     
-                    BlogHeaderView()
+                    BlogHeaderView(blog: blog)
                     
                     GeometryReader { geometry in
                         Color.clear
@@ -106,7 +106,7 @@ struct BlogView: View {
             
         } //ZStack
         .onAppear {
-            viewModel.initBlogID(blog.id)
+            viewModel.initBlog(blog)
             Task {
                 await viewModel.getPostsInBlog()
             }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -35,7 +35,7 @@ struct BlogView: View {
                     
                     
                     // 인기글 TODO: 인기글 모두보기 View
-                    PopularBlogPostListView()
+                    PopularBlogPostListView(blog: blog)
                     
                     // 카테고리 별 글 TODO: 카테고리 선택 sheet 및 카테고리 별로 분류
                     BlogPostListView()

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostCell.swift
@@ -79,7 +79,7 @@ struct PopularBlogPostCell: View {
         } //VStack
         .background(Color.white)
         .overlay {
-            contentViewModel.navigateToPostViewButton(tempPost())
+            contentViewModel.navigateToPostViewButton(post)
         }
     }
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostCell.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct PopularBlogPostCell: View {
+    let post: Post
+    
     @Environment(\.contentViewModel) var contentViewModel
     @Environment(\.blogViewModel) var viewModel
     
@@ -15,7 +17,7 @@ struct PopularBlogPostCell: View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("제목제목제목제목제목제목제목제목제목제목제목제목제목제목")
+                    Text(post.title)
                         .font(.system(size: 18, weight: .light))
                         .lineLimit(1)
                     
@@ -26,7 +28,7 @@ struct PopularBlogPostCell: View {
                         HStack(alignment: .center, spacing: 3) {
                             Image(systemName: "heart")
                             
-                            Text("50")
+                            Text("\(post.likeCount)")
                         }
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)
@@ -38,7 +40,7 @@ struct PopularBlogPostCell: View {
                         HStack(alignment: .center, spacing: 3) {
                             Image(systemName: "ellipsis.bubble")
                             
-                            Text("5")
+                            Text("\(post.commentCount)")
                         }
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)
@@ -50,7 +52,7 @@ struct PopularBlogPostCell: View {
                         HStack(alignment: .center, spacing: 3) {
                             Text("조회")
                             
-                            Text("999+")
+                            Text(post.viewCount >= 1000 ? "999+" : "\(post.viewCount)")
                         }
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostListView.swift
@@ -35,8 +35,8 @@ struct PopularBlogPostListView: View {
                 .frame(height: 10)
             
             LazyVStack(spacing: 0) {
-                ForEach(Array(viewModel.popularBlogPosts.prefix(3).enumerated()), id: \.offset) { index, item in
-                    PopularBlogPostCell()
+                ForEach(Array(viewModel.popularBlogPosts.prefix(3).enumerated()), id: \.offset) { index, post in
+                    PopularBlogPostCell(post: post)
                     Divider()
                         .foregroundStyle(index == 2 ? Color.clear : Color.secondaryLabelColor)
                 }

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostListView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct PopularBlogPostListView: View {
+    let blog: Blog
+    
     @Environment(\.blogViewModel) var viewModel
     @Environment(\.contentViewModel) var contentViewModel
     
@@ -23,7 +25,7 @@ struct PopularBlogPostListView: View {
                 
                 Spacer()
                 
-                NavigationLink(destination: PopularBlogPostSheetView()) {
+                NavigationLink(destination: PopularBlogPostSheetView(blog: blog)) {
                     Text("모두보기")
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)
@@ -45,5 +47,6 @@ struct PopularBlogPostListView: View {
             .shadow(color: Color.black.opacity(0.1), radius: 7)
         }
         .padding(.horizontal, 20)
+        
     }
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostListView.swift
@@ -35,7 +35,7 @@ struct PopularBlogPostListView: View {
                 .frame(height: 10)
             
             LazyVStack(spacing: 0) {
-                ForEach(Array(viewModel.popularBlogPostItems[0..<3].enumerated()), id: \.offset) { index, item in
+                ForEach(Array(viewModel.popularBlogPosts.prefix(3).enumerated()), id: \.offset) { index, item in
                     PopularBlogPostCell()
                     Divider()
                         .foregroundStyle(index == 2 ? Color.clear : Color.secondaryLabelColor)

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetCell.swift
@@ -88,7 +88,7 @@ struct PopularBlogPostSheetCell: View {
         } //VStack
         .background(Color.white)
         .overlay {
-            contentViewModel.navigateToPostViewButton(tempPost())
+            contentViewModel.navigateToPostViewButton(post)
         }
     }
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetCell.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct PopularBlogPostSheetCell: View {
+    let post: Post
     let index: Int
     @Bindable var viewModel: PopularBlogPostSheetViewModel
     @Environment(\.contentViewModel) var contentViewModel
@@ -24,7 +25,7 @@ struct PopularBlogPostSheetCell: View {
                     .frame(width: 10)
                 
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("제목제목제목제목제목제목제목제목제목제목제목제목제목제목")
+                    Text(post.title)
                         .font(.system(size: 18, weight: .light))
                         .lineLimit(1)
                     
@@ -35,7 +36,7 @@ struct PopularBlogPostSheetCell: View {
                         HStack(alignment: .center, spacing: 3) {
                             Image(systemName: "heart")
                             
-                            Text("50")
+                            Text("\(post.likeCount)")
                         }
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)
@@ -47,7 +48,7 @@ struct PopularBlogPostSheetCell: View {
                         HStack(alignment: .center, spacing: 3) {
                             Image(systemName: "ellipsis.bubble")
                             
-                            Text("5")
+                            Text("\(post.commentCount)")
                         }
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)
@@ -59,7 +60,7 @@ struct PopularBlogPostSheetCell: View {
                         HStack(alignment: .center, spacing: 3) {
                             Text("조회")
                             
-                            Text("999+")
+                            Text(post.viewCount >= 1000 ? "999+" : "\(post.viewCount)")
                         }
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct PopularBlogPostSheetView: View {
-    @State var viewModel = PopularBlogPostSheetViewModel()
+    let blog: Blog
     
+    @State var viewModel = PopularBlogPostSheetViewModel()
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
@@ -46,7 +47,7 @@ struct PopularBlogPostSheetView: View {
                             viewModel.toggleIsCriterionSelectionSheetPresent()
                         }) {
                             HStack(spacing: 0) {
-                                Text("\(viewModel.getSortCriterion())  ")
+                                Text("\(viewModel.getSortCriterion().korName)  ")
                                 
                                 Image(systemName: "chevron.down")
                             }
@@ -61,8 +62,8 @@ struct PopularBlogPostSheetView: View {
                     
                     //MARK: PostList
                     LazyVStack(spacing: 0) {
-                        ForEach(Array(viewModel.popularBlogPostItems.enumerated()), id: \.offset) { index, item in
-                            PopularBlogPostSheetCell(index: index + 1, viewModel: viewModel)
+                        ForEach(Array(viewModel.popularBlogPosts.enumerated()), id: \.offset) { index, post in
+                            PopularBlogPostSheetCell(post: post, index: index + 1, viewModel: viewModel)
                             
                             Divider()
                                 .foregroundStyle(Color.secondaryLabelColor)
@@ -122,6 +123,12 @@ struct PopularBlogPostSheetView: View {
             .ignoresSafeArea()
         
         } //VStack
+        .onAppear {
+            viewModel.initBlogID(blog.id)
+            Task {
+                await viewModel.getPopularBlogPosts()
+            }
+        }
         // MARK: NavBar
         // TODO: rightTabButton - 검색버튼과 본인계정버튼은 4개의 TabView에 공통 적용이므로 추후 제작
         .navigationTitle(Text(viewModel.getIsNavTitleHidden() ? "" : "인기글"))
@@ -143,13 +150,17 @@ struct PopularBlogPostSheetView: View {
     }
     
     //MARK: CriterionSelectionSheet Row(Button)
-    @ViewBuilder func CriterionSelectionButton(for criterion: String, isLast: Bool, rowHeight: CGFloat) -> some View {
+    @ViewBuilder func CriterionSelectionButton(for criterion: PopularPostSortedType, isLast: Bool, rowHeight: CGFloat) -> some View {
         Button(action: {
+            print(criterion)
             viewModel.setSortCriterion(to: criterion)
             viewModel.toggleIsCriterionSelectionSheetPresent()
+            Task {
+                await viewModel.getPopularBlogPosts()
+            }
         }) {
             HStack(spacing: 0) {
-                Text("\(criterion)")
+                Text("\(criterion.korName)")
                     .font(.system(size: 17, weight: viewModel.isCurrentSortCriterion(is: criterion) ? .semibold : .light))
                     .foregroundStyle(Color.primaryLabelColor)
                     .padding()
@@ -173,31 +184,3 @@ struct PopularBlogPostSheetView: View {
 }
 
 
-
-enum PopularPostSortedType: String, CaseIterable {
-    case views
-    case comments
-    case likes
-    
-    var korName: String {
-        switch self {
-        case .views:
-            return "조회순"
-        case .comments:
-            return "댓글순"
-        case .likes:
-            return "공감순"
-        }
-    }
-    
-    var api: String {
-        switch self {
-        case .views:
-            return "views"
-        case .comments:
-            return "comments"
-        case .likes:
-            return "likes"
-        }
-    }
-}

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetView.swift
@@ -124,7 +124,7 @@ struct PopularBlogPostSheetView: View {
         
         } //VStack
         .onAppear {
-            viewModel.initBlogID(blog.id)
+            viewModel.initBlog(blog)
             Task {
                 await viewModel.getPopularBlogPosts()
             }

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetView.swift
@@ -171,3 +171,33 @@ struct PopularBlogPostSheetView: View {
         }
     }
 }
+
+
+
+enum PopularPostSortedType: String, CaseIterable {
+    case views
+    case comments
+    case likes
+    
+    var korName: String {
+        switch self {
+        case .views:
+            return "조회순"
+        case .comments:
+            return "댓글순"
+        case .likes:
+            return "공감순"
+        }
+    }
+    
+    var api: String {
+        switch self {
+        case .views:
+            return "views"
+        case .comments:
+            return "comments"
+        case .likes:
+            return "likes"
+        }
+    }
+}

--- a/Wastory/Wastory/View/ContentView/PostView/BlogPopularPostGrid/BlogPopularPostGridCell.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/BlogPopularPostGrid/BlogPopularPostGridCell.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct BlogPopularPostGridCell: View {
-    
     @Environment(\.contentViewModel) var contentViewModel
     @Environment(\.postViewModel) var viewModel
     
@@ -46,7 +45,3 @@ struct BlogPopularPostGridCell: View {
     }
 }
 
-
-#Preview {
-    BlogPostListCell()
-}

--- a/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListCell.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListCell.swift
@@ -94,8 +94,3 @@ struct CategoryPostListCell: View {
         }
     }
 }
-
-
-#Preview {
-    BlogPostListCell()
-}

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
@@ -13,7 +13,6 @@ import Observation
 @Observable final class BlogViewModel {
     var blogID: Int = 0
     
-    
     func initBlogID(_ id: Int) {
         blogID = id
     }

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
@@ -82,6 +82,11 @@ import Observation
     var page = 1
     var isPageEnded: Bool = false
     
+    func resetPage() {
+        page = 1
+        isPageEnded = false
+    }
+    
     
     //Network
     var popularBlogPosts: [Post] = []
@@ -113,6 +118,7 @@ import Observation
         }
     }
     
+    // - 블로그 내 인기글List views 순으로 get하기 (pagination 기능 있음)
     func getPopularBlogPosts() async {
         do {
             popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blogID, sortBy: PopularPostSortedType.views.api)

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
@@ -11,6 +11,14 @@ import SwiftUI
 import Observation
 
 @Observable final class BlogViewModel {
+    var blogID: Int = 0
+    
+    
+    func initBlogID(_ id: Int) {
+        blogID = id
+    }
+    
+    
     private var isNavTitleHidden: Bool = true
     
     private var initialScrollPosition: CGFloat = 0
@@ -23,9 +31,6 @@ import Observation
     var selectedCategory: String = "분류 전체보기"
     
     
-    var popularBlogPostItems: [String] = ["item 1", "item 2", "item 3", "item 4", "item 5", "item 6", "item 7", "item 8", "item 9", "item 10"]
-    
-    var blogPostListItems: [String] = ["item 1", "item 2", "item 3", "item 4", "item 5", "item 6", "item 7", "item 8", "item 9", "item 10"]
     
     
     func setInitialScrollPosition(_ scrollPosition: CGFloat) {
@@ -70,6 +75,52 @@ import Observation
     func setCategory(to category: String) {
         selectedCategory = category
     }
+    
+    
+    
+    //pagination
+    var page = 1
+    var isPageEnded: Bool = false
+    
+    
+    //Network
+    var popularBlogPosts: [Post] = []
+    
+    var blogPosts: [Post] = []
+    
+    // - 블로그 내 글List get하기 (pagination 기능 있음)
+    func getPostsInBlog() async {
+        if !isPageEnded {
+            do {
+                let response = try await NetworkRepository.shared.getArticlesInBlog(blogID: self.blogID, page: self.page)
+                
+                //comments 저장
+                if self.page == 1 {
+                    blogPosts = response
+                } else {
+                    blogPosts.append(contentsOf: response)
+                }
+                
+                //pagination
+                if !response.isEmpty {
+                    self.page += 1
+                } else {
+                    self.isPageEnded = true
+                }
+            } catch {
+                print("Error: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func getPopularBlogPosts() async {
+        do {
+            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blogID, sortBy: PopularPostSortedType.views.api)
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }
+    }
+    
 }
 
 

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
@@ -11,10 +11,10 @@ import SwiftUI
 import Observation
 
 @Observable final class BlogViewModel {
-    var blogID: Int = 0
+    var blog: Blog?
     
-    func initBlogID(_ id: Int) {
-        blogID = id
+    func initBlog(_ blog: Blog) {
+        self.blog = blog
     }
     
     
@@ -96,7 +96,7 @@ import Observation
     func getPostsInBlog() async {
         if !isPageEnded {
             do {
-                let response = try await NetworkRepository.shared.getArticlesInBlog(blogID: self.blogID, page: self.page)
+                let response = try await NetworkRepository.shared.getArticlesInBlog(blogID: self.blog!.id, page: self.page)
                 
                 //comments 저장
                 if self.page == 1 {
@@ -120,7 +120,7 @@ import Observation
     // - 블로그 내 인기글List views 순으로 get하기 (pagination 기능 있음)
     func getPopularBlogPosts() async {
         do {
-            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blogID, sortBy: PopularPostSortedType.views.api)
+            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blog!.id, sortBy: PopularPostSortedType.views.api)
         } catch {
             print("Error: \(error.localizedDescription)")
         }

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/PopularBlogPostSheetViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/PopularBlogPostSheetViewModel.swift
@@ -11,6 +11,14 @@ import SwiftUI
 import Observation
 
 @Observable final class PopularBlogPostSheetViewModel {
+    var blogID: Int = 0
+    
+    func initBlogID(_ id: Int) {
+        blogID = id
+    }
+    
+    
+    
     private var isNavTitleHidden: Bool = true
     
     private var initialScrollPosition: CGFloat = 0
@@ -18,9 +26,9 @@ import Observation
     var isNavigationToNextPost: Bool = false
     
     
-    private var sortCriterion: String = "조회순"
+    private var sortCriterion: PopularPostSortedType = .views
     
-    let sortCriterions = ["조회순", "공감순", "댓글순"]
+    let sortCriterions: [PopularPostSortedType] = [.views, .likes, .comments]
     
     var popularBlogPostItems: [String] = ["item 1", "item 2", "item 3", "item 4", "item 5", "item 6", "item 7", "item 8", "item 9", "item 10", "item 11", "item 12", "item 13", "item 14", "item 15", "item 16", "item 17", "item 18", "item 19", "item 20"]
     
@@ -55,15 +63,15 @@ import Observation
     }
     
     
-    func getSortCriterion() -> String {
+    func getSortCriterion() -> PopularPostSortedType {
         sortCriterion
     }
     
-    func setSortCriterion(to criterion: String) {
+    func setSortCriterion(to criterion: PopularPostSortedType) {
         sortCriterion = criterion
     }
     
-    func isCurrentSortCriterion(is criterion: String) -> Bool {
+    func isCurrentSortCriterion(is criterion: PopularPostSortedType) -> Bool {
         sortCriterion == criterion
     }
     
@@ -72,4 +80,46 @@ import Observation
             isCriterionSelectionSheetPresent.toggle()
         }
     }
+    
+    
+    //Network
+    var popularBlogPosts: [Post] = []
+    
+    func getPopularBlogPosts() async {
+        do {
+            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blogID, sortBy: sortCriterion.api)
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }
+    }
 }
+
+
+enum PopularPostSortedType: String, CaseIterable {
+    case views
+    case comments
+    case likes
+    
+    var korName: String {
+        switch self {
+        case .views:
+            return "조회순"
+        case .comments:
+            return "댓글순"
+        case .likes:
+            return "공감순"
+        }
+    }
+    
+    var api: String {
+        switch self {
+        case .views:
+            return "views"
+        case .comments:
+            return "comments"
+        case .likes:
+            return "likes"
+        }
+    }
+}
+

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/PopularBlogPostSheetViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/PopularBlogPostSheetViewModel.swift
@@ -11,10 +11,10 @@ import SwiftUI
 import Observation
 
 @Observable final class PopularBlogPostSheetViewModel {
-    var blogID: Int = 0
+    var blog: Blog?
     
-    func initBlogID(_ id: Int) {
-        blogID = id
+    func initBlog(_ blog: Blog) {
+        self.blog = blog
     }
     
     
@@ -87,7 +87,7 @@ import Observation
     
     func getPopularBlogPosts() async {
         do {
-            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blogID, sortBy: sortCriterion.api)
+            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blog!.id, sortBy: sortCriterion.api)
         } catch {
             print("Error: \(error.localizedDescription)")
         }

--- a/Wastory/Wastory/ViewModel/ContentViewModel/CommentViewModel/CommentViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/CommentViewModel/CommentViewModel.swift
@@ -44,6 +44,10 @@ import Observation
     var page = 1
     var isPageEnded: Bool = false
     
+    func resetPage() {
+        page = 1
+        isPageEnded = false
+    }
     
     //Network
     var postID: Int?
@@ -123,8 +127,5 @@ import Observation
         }
     }
     
-    func resetPage() {
-        page = 1
-    }
 }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[O] 기능 추가
 -[] 기능 삭제
 -[] 버그 수정
 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Feature/connect blog view  -> main

### 변경 사항 
blogView에서 인기글, 전체글을 불러올 수 있습니다.
PopularBlogPostSheet에서 각 정렬조건을 선택해 인기순으로 최대 20개의 글을 불러 올 수 있습니다.
.refreshable 을 이용해서 화면을 아래로 끌어당겨 새로고침도 가능합니다. (다른 새로고침이 필요한 View들도 scorllView나 List, LazyVStack에 .refreshable을 달면 새로고침 될 것 같습니다.) 시뮬레이터에서는 아무 UI도 안나오는데 아이패드로 실행 결과 새로고침 UI가 나옵니다.


### 추후 보완 사항

카테고리 선택기능은 카테고리 api가 수정된 후, 카테고리 생성화면부터 연결 한 뒤에 하면 되겠습니다.
getPostsInBlog에서 현재 선택된 카테고리가 있을 경우  get articles in blog in category를 호출하게 해야될 것 같습니다.


https://github.com/user-attachments/assets/c89d4190-8289-400f-8909-e8738e71bafa


