### PR TITLE
Feature/post blog view restruct

### DIFF
--- a/Wastory/Wastory.xcodeproj/project.pbxproj
+++ b/Wastory/Wastory.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -323,6 +324,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Wastory/Wastory.xcodeproj/project.pbxproj
+++ b/Wastory/Wastory.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Wastory/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -316,6 +317,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Wastory/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Wastory/Wastory.xcodeproj/project.pbxproj
+++ b/Wastory/Wastory.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "waffle-toyproject-team5.Wastory";
+				PRODUCT_BUNDLE_IDENTIFIER = com.wafflestudio.Wastory;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -328,7 +328,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "waffle-toyproject-team5.Wastory";
+				PRODUCT_BUNDLE_IDENTIFIER = com.wafflestudio.Wastory;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Wastory/Wastory/Info.plist
+++ b/Wastory/Wastory/Info.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>kakaokompassauth</string>
-		<string>kakaolink</string>
-	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -19,6 +14,11 @@
 				<string>wastory</string>
 			</array>
 		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
 	</array>
 </dict>
 </plist>

--- a/Wastory/Wastory/Model/Blog.swift
+++ b/Wastory/Wastory/Model/Blog.swift
@@ -34,7 +34,7 @@ struct Blog: Codable, Identifiable, Hashable {
 import SwiftUI
 extension View {
     func tempBlog() -> Blog {
-        Blog.init(id: 5, blogName: "블로그 이름", addressName: "WaSans", description: "블로그 설명어어어어엉엉", userID: 0)
+        Blog.init(id: 1, blogName: "블로그 이름", addressName: "WaSans", description: "블로그 설명어어어어엉엉", userID: 0)
     }
 }
 

--- a/Wastory/Wastory/Model/Blog.swift
+++ b/Wastory/Wastory/Model/Blog.swift
@@ -31,6 +31,23 @@ struct Blog: Codable, Identifiable, Hashable {
         }()
 }
 
+
+struct BlogListDto: Codable {
+    let page: Int
+    let perPage: Int
+    let totalCount: Int
+    let blogs: [Blog]
+    
+    private enum CodingKeys: String, CodingKey {
+        case page
+        case perPage = "per_page"
+        case totalCount = "total_count"
+        case blogs
+    }
+}
+
+
+
 import SwiftUI
 extension View {
     func tempBlog() -> Blog {

--- a/Wastory/Wastory/Model/Category.swift
+++ b/Wastory/Wastory/Model/Category.swift
@@ -13,7 +13,7 @@ struct Category: Codable, Identifiable, Hashable {
     var categoryName: String
     var level: Int?
     var articleCount: Int?
-    var children: [Category] = []
+    var children: [Category]? = []
     
     private enum CodingKeys: String, CodingKey {
         case id

--- a/Wastory/Wastory/Model/Category.swift
+++ b/Wastory/Wastory/Model/Category.swift
@@ -30,7 +30,7 @@ struct Category: Codable, Identifiable, Hashable {
 
 struct CategoryListDto: Codable {
     let categories: [Category]
-    
+   
     private enum CodingKeys: String, CodingKey {
         case categories = "category_list"
     }

--- a/Wastory/Wastory/Model/HomeTopic.swift
+++ b/Wastory/Wastory/Model/HomeTopic.swift
@@ -1,0 +1,29 @@
+//
+//  HomeTopic.swift
+//  Wastory
+//
+//  Created by 중워니 on 1/27/25.
+//
+
+
+import Foundation
+
+struct HomeTopic: Codable, Identifiable, Hashable {
+    let id: Int
+    var name: String
+    var highCategory: Int
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case highCategory = "high_category"
+    }
+    
+    static let defaultHomeTopic: HomeTopic = {
+        HomeTopic(id: 0, name: "", highCategory: 0)
+    }()
+}
+
+struct HomeTopicListDto: Codable {
+    let hometopics: [HomeTopic]
+}

--- a/Wastory/Wastory/Model/Post.swift
+++ b/Wastory/Wastory/Model/Post.swift
@@ -11,7 +11,6 @@ struct Post: Codable, Identifiable, Hashable {
     let id: Int                    // Post Id(주소)
         
     var homeTopicID: Int?          // Post의 홈토픽 Id
-    var categoryID: Int?           // Post가 블로그 내에 속한 카테고리 Id (카테고리 미제작 시 불필요)
         
     var title: String               // Post 제목
     var content: String?            // Post 내용 (HTML을 String으로 변환하여 저장)
@@ -21,6 +20,7 @@ struct Post: Codable, Identifiable, Hashable {
     var blogName: String?           // Blog 이름
     var blogMainImageURL: String?   // Blog 대표이미지 URL
     var mainImageUrl: String?       // Post 대표이미지 URL
+    var categoryID: Int?           // Post가 블로그 내에 속한 카테고리 Id (카테고리 미제작 시 불필요)
     var viewCount: Int              // 조회수
     var likeCount: Int              // Like 개수
     var commentCount: Int           // Comment 개수
@@ -28,7 +28,6 @@ struct Post: Codable, Identifiable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case id
         case homeTopicID
-        case categoryID
         case title
         case content
         case description
@@ -37,6 +36,7 @@ struct Post: Codable, Identifiable, Hashable {
         case blogName = "blog_name"
         case blogMainImageURL = "blog_main_image_url"
         case mainImageUrl = "main_image_url"
+        case categoryID = "category_id"
         case viewCount = "views"
         case likeCount = "article_likes"
         case commentCount = "article_comments"

--- a/Wastory/Wastory/Model/Subscription.swift
+++ b/Wastory/Wastory/Model/Subscription.swift
@@ -1,0 +1,16 @@
+//
+//  Subscription.swift
+//  Wastory
+//
+//  Created by 중워니 on 1/3/25.
+//
+
+import Foundation
+
+struct SubscriptionDto: Codable {
+    let isSubscribing: Bool
+    
+    private enum CodingKeys: String, CodingKey {
+        case isSubscribing = "is_subscribing"
+    }
+}

--- a/Wastory/Wastory/Model/TimeAgoConverter.swift
+++ b/Wastory/Wastory/Model/TimeAgoConverter.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 func timeAgo(from date: Date) -> String {
-    let secondsAgo = Int(Date().timeIntervalSince(date)) - (60 * 60 * 9)
+    let secondsAgo = Int(Date().timeIntervalSince(date))// - (60 * 60 * 9)
     
     switch secondsAgo {
     case 0..<60:

--- a/Wastory/Wastory/Model/TimeAgoConverter.swift
+++ b/Wastory/Wastory/Model/TimeAgoConverter.swift
@@ -11,7 +11,9 @@ func timeAgo(from date: Date) -> String {
     let secondsAgo = Int(Date().timeIntervalSince(date))// - (60 * 60 * 9)
     
     switch secondsAgo {
-    case 0..<60:
+    case 0..<3:
+        return "방금"
+    case 3..<60:
         return "\(secondsAgo)초 전"
     case 60..<(60 * 60):
         let minutes = secondsAgo / 60

--- a/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
@@ -321,6 +321,35 @@ extension NetworkRepository {
         return response.articles
         
     }
+    
+    func getArticle(postID: Int) async throws -> Post {
+        let urlRequest = try URLRequest(
+            url: NetworkRouter.getArticle(postID: postID).url,
+            method: NetworkRouter.getArticle(postID: postID).method,
+            headers: NetworkRouter.getArticle(postID: postID).headers
+        )
+        
+        logRequest(urlRequest)
+        
+        // ISO8601DateFormatter로 날짜 처리
+        let decoder = JSONDecoder()
+        
+        // DateFormatter를 사용하여 ISO8601 형식을 맞추기
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(Post.self, decoder: decoder)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response
+    }
         
     
     // MARK: - Comment

--- a/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
@@ -254,6 +254,28 @@ extension NetworkRepository {
         logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
     }
     
+    func getCategory(categoryID: Int) async throws -> Category {
+        let urlRequest = try URLRequest(
+            url:     NetworkRouter.getCategory(categoryID: categoryID).url,
+            method:  NetworkRouter.getCategory(categoryID: categoryID).method,
+            headers: NetworkRouter.getCategory(categoryID: categoryID).headers
+        )
+        
+        logRequest(urlRequest)
+        
+        // 응답 데이터 확인
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(Category.self)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response
+    }
+    
     // MARK: - Article
     func getTopArticlesInBlog(blogID: Int, sortBy: String) async throws -> [Post] {
         let urlRequest = try URLRequest(
@@ -350,7 +372,220 @@ extension NetworkRepository {
         
         return response
     }
+    
+    func getArticlesTodayWastory() async throws -> [Post] {
+        var urlRequest = try URLRequest(
+            url: NetworkRouter.getArticlesTodayWastory.url,
+            method: NetworkRouter.getArticlesTodayWastory.method,
+            headers: NetworkRouter.getArticlesTodayWastory.headers
+        )
         
+        if let url = urlRequest.url {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            components?.queryItems = [
+                URLQueryItem(name: "page", value: "1")
+            ]
+            urlRequest.url = components?.url
+        }
+        
+        logRequest(urlRequest)
+        
+        // ISO8601DateFormatter로 날짜 처리
+        let decoder = JSONDecoder()
+        
+        // DateFormatter를 사용하여 ISO8601 형식을 맞추기
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(PostListDto.self, decoder: decoder)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response.articles
+    }
+    
+    func getArticlesWeeklyWastory() async throws -> [Post] {
+        var urlRequest = try URLRequest(
+            url: NetworkRouter.getArticlesWeeklyWastory.url,
+            method: NetworkRouter.getArticlesWeeklyWastory.method,
+            headers: NetworkRouter.getArticlesWeeklyWastory.headers
+        )
+        
+        logRequest(urlRequest)
+        
+        // ISO8601DateFormatter로 날짜 처리
+        let decoder = JSONDecoder()
+        
+        // DateFormatter를 사용하여 ISO8601 형식을 맞추기
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(PostListDto.self, decoder: decoder)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response.articles
+    }
+    
+    func getArticlesHomeTopic(highHomeTopicID: Int) async throws -> [Post] {
+        var urlRequest = try URLRequest(
+            url: NetworkRouter.getArticlesHomeTopic(highHomeTopicID: highHomeTopicID).url,
+            method: NetworkRouter.getArticlesHomeTopic(highHomeTopicID: highHomeTopicID).method,
+            headers: NetworkRouter.getArticlesHomeTopic(highHomeTopicID: highHomeTopicID).headers
+        )
+        
+        if let url = urlRequest.url {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            components?.queryItems = [
+                URLQueryItem(name: "page", value: "1")
+            ]
+            urlRequest.url = components?.url
+        }
+        
+        logRequest(urlRequest)
+        
+        // ISO8601DateFormatter로 날짜 처리
+        let decoder = JSONDecoder()
+        
+        // DateFormatter를 사용하여 ISO8601 형식을 맞추기
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(PostListDto.self, decoder: decoder)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response.articles
+    }
+    
+    func getArticlesOfSubscription(blogID: Int, page: Int) async throws -> [Post] {
+        var urlRequest = try URLRequest(
+            url:     NetworkRouter.getArticlesOfSubscription(blogID: blogID).url,
+            method:  NetworkRouter.getArticlesOfSubscription(blogID: blogID).method,
+            headers: NetworkRouter.getArticlesOfSubscription(blogID: blogID).headers
+        )
+        
+        if let url = urlRequest.url {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            components?.queryItems = [
+                URLQueryItem(name: "page", value: "\(page)")
+            ]
+            urlRequest.url = components?.url
+        }
+        
+        logRequest(urlRequest)
+        
+        // ISO8601DateFormatter로 날짜 처리
+        let decoder = JSONDecoder()
+        
+        // DateFormatter를 사용하여 ISO8601 형식을 맞추기
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(PostListDto.self, decoder: decoder)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response.articles
+    }
+    
+    func searchArticlesInBlog(searchingWord: String, blogID: Int, page: Int) async throws -> PostListDto {
+        var urlRequest = try URLRequest(
+            url:     NetworkRouter.searchArticlesInBlog(searchingWord: searchingWord, blogID: blogID).url,
+            method:  NetworkRouter.searchArticlesInBlog(searchingWord: searchingWord, blogID: blogID).method,
+            headers: NetworkRouter.searchArticlesInBlog(searchingWord: searchingWord, blogID: blogID).headers
+        )
+        
+        if let url = urlRequest.url {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            components?.queryItems = [
+                URLQueryItem(name: "page", value: "\(page)")
+            ]
+            urlRequest.url = components?.url
+        }
+        
+        logRequest(urlRequest)
+        
+        // ISO8601DateFormatter로 날짜 처리
+        let decoder = JSONDecoder()
+        
+        // DateFormatter를 사용하여 ISO8601 형식을 맞추기
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(PostListDto.self, decoder: decoder)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response
+    }
+    
+    func searchArticles(searchingWord: String, page: Int) async throws -> PostListDto {
+        var urlRequest = try URLRequest(
+            url:     NetworkRouter.searchArticles(searchingWord: searchingWord).url,
+            method:  NetworkRouter.searchArticles(searchingWord: searchingWord).method,
+            headers: NetworkRouter.searchArticles(searchingWord: searchingWord).headers
+        )
+        
+        if let url = urlRequest.url {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            components?.queryItems = [
+                URLQueryItem(name: "page", value: "\(page)")
+            ]
+            urlRequest.url = components?.url
+        }
+        
+        logRequest(urlRequest)
+        
+        // ISO8601DateFormatter로 날짜 처리
+        let decoder = JSONDecoder()
+        
+        // DateFormatter를 사용하여 ISO8601 형식을 맞추기
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(PostListDto.self, decoder: decoder)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response
+    }
     
     // MARK: - Comment
     func postComment(postID: Int, content: String, parentID: Int?, isSecret: Bool) async throws {

--- a/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
@@ -654,6 +654,124 @@ extension NetworkRepository {
         return response
     }
     
+    // MARK: - Subscription
+    func postSubscription(blogID: Int) async throws {
+        var urlRequest = try URLRequest(
+            url:     NetworkRouter.postSubscription.url,
+            method:  NetworkRouter.postSubscription.method,
+            headers: NetworkRouter.postSubscription.headers
+        )
+        
+        if let url = urlRequest.url {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            components?.queryItems = [
+                URLQueryItem(name: "subscribed_id", value: "\(blogID)")
+            ]
+            urlRequest.url = components?.url
+        }
+        
+        logRequest(urlRequest)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingData()
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+    }
+    
+    func deleteSubscription(blogAddress: String) async throws {
+        var urlRequest = try URLRequest(
+            url:     NetworkRouter.deleteSubscription.url,
+            method:  NetworkRouter.deleteSubscription.method,
+            headers: NetworkRouter.deleteSubscription.headers
+        )
+        
+        if let url = urlRequest.url {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            components?.queryItems = [
+                URLQueryItem(name: "subscribed_address_name", value: blogAddress)
+            ]
+            urlRequest.url = components?.url
+        }
+        
+        logRequest(urlRequest)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingData()
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+    }
+    
+    func getSubscribingBlogs(page: Int) async throws -> BlogListDto {
+        var urlRequest = try URLRequest(
+            url:     NetworkRouter.getSubscribingBlogs(page:  page).url,
+            method:  NetworkRouter.getSubscribingBlogs(page:  page).method,
+            headers: NetworkRouter.getSubscribingBlogs(page:  page).headers
+        )
+        
+        logRequest(urlRequest)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(BlogListDto.self)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response
+    }
+    
+    func getSubscriberBlogs(page: Int) async throws -> BlogListDto {
+        var urlRequest = try URLRequest(
+            url:     NetworkRouter.getSubscriberBlogs(page:  page).url,
+            method:  NetworkRouter.getSubscriberBlogs(page:  page).method,
+            headers: NetworkRouter.getSubscriberBlogs(page:  page).headers
+        )
+        
+        logRequest(urlRequest)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(BlogListDto.self)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response
+    }
+    
+    func getIsSubscribing(BlogID: Int) async throws -> Bool {
+        var urlRequest = try URLRequest(
+            url:     NetworkRouter.getIsSubscribing.url,
+            method:  NetworkRouter.getIsSubscribing.method,
+            headers: NetworkRouter.getIsSubscribing.headers
+        )
+        
+        logRequest(urlRequest)
+        
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+        .serializingDecodable(SubscriptionDto.self)
+        .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response.isSubscribing
+    }
+    
     // MARK: - Like
     func postLike(postID: Int) async throws {
         let requestBody = [

--- a/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
@@ -411,7 +411,7 @@ extension NetworkRepository {
     }
     
     func getArticlesWeeklyWastory() async throws -> [Post] {
-        var urlRequest = try URLRequest(
+        let urlRequest = try URLRequest(
             url: NetworkRouter.getArticlesWeeklyWastory.url,
             method: NetworkRouter.getArticlesWeeklyWastory.method,
             headers: NetworkRouter.getArticlesWeeklyWastory.headers

--- a/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
@@ -449,6 +449,7 @@ extension NetworkRepository {
         if let url = urlRequest.url {
             var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
             components?.queryItems = [
+                URLQueryItem(name: "high_hometopic_id", value: "\(highHomeTopicID)"),
                 URLQueryItem(name: "page", value: "1")
             ]
             urlRequest.url = components?.url
@@ -834,5 +835,27 @@ extension NetworkRepository {
         
         logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
     }
-
+    
+    // MARK: - HomeTopic
+    func getHomeTopicList() async throws -> [HomeTopic] {
+        let urlRequest = try URLRequest(
+            url:     NetworkRouter.getHomeTopicList.url,
+            method:  NetworkRouter.getHomeTopicList.method,
+            headers: NetworkRouter.getHomeTopicList.headers
+        )
+        
+        logRequest(urlRequest)
+        
+        // 응답 데이터 확인
+        let response = try await AF.request(
+            urlRequest,
+            interceptor: NetworkInterceptor()
+        ).validate()
+            .serializingDecodable(HomeTopicListDto.self)
+            .value
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response.hometopics
+    }
 }

--- a/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository-Joong.swift
@@ -640,36 +640,17 @@ extension NetworkRepository {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
-        let rawResponse = try await AF.request(
+        
+        let response = try await AF.request(
             urlRequest,
             interceptor: NetworkInterceptor()
         ).validate()
-        .serializingString()
+        .serializingDecodable(CommentListDto.self, decoder: decoder)
         .value
-
-        // 응답 원문 로그 출력
-        logResponse(rawResponse, url: urlRequest.url?.absoluteString ?? "unknown")
-
-        // JSON 디코더로 다시 CommentListDto로 디코딩
-        guard let responseData = rawResponse.data(using: .utf8) else {
-            throw NSError(domain: "Invalid response data", code: -1, userInfo: nil)
-        }
-
-        let decodedResponse = try decoder.decode(CommentListDto.self, from: responseData)
-
-        // 최종 디코딩된 데이터 반환
-        logResponse(decodedResponse, url: urlRequest.url?.absoluteString ?? "unknown")
-        return decodedResponse
-//        let response = try await AF.request(
-//            urlRequest,
-//            interceptor: NetworkInterceptor()
-//        ).validate()
-//        .serializingDecodable(CommentListDto.self, decoder: decoder)
-//        .value
-//        
-//        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
-//        
-//        return response
+        
+        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
+        
+        return response
     }
     
     // MARK: - Like

--- a/Wastory/Wastory/Repository/NetworkRouter.swift
+++ b/Wastory/Wastory/Repository/NetworkRouter.swift
@@ -51,6 +51,13 @@ enum NetworkRouter {
     case postComment(postID: Int)
     case getArticleComments(postID: Int, page: Int)
     
+    // MARK: Subscription
+    case postSubscription
+    case deleteSubscription
+    case getSubscribingBlogs(page: Int)
+    case getSubscriberBlogs(page: Int)
+    case getIsSubscribing
+    
     //MARK: Like
     case postLike
     case getIsLiked(postID: Int)
@@ -112,6 +119,13 @@ enum NetworkRouter {
         // MARK: Comment
         case let .postComment(postID): "/comments/article/\(postID)"
         case let .getArticleComments(postID, page): "/comments/article/\(postID)/\(page)"
+            
+        // MARK: Subscription
+        case .postSubscription: "/subscription"
+        case .deleteSubscription: "/subscription"
+        case let .getSubscribingBlogs(page): "/subscription/my_subscriptions/\(page)"
+        case let .getSubscriberBlogs(page): "/subscription/my_subscribers/\(page)"
+        case .getIsSubscribing: "/subscription/is_subscribing"
             
         //MARK: Like
         case .postLike: "/likes/create"
@@ -202,6 +216,18 @@ enum NetworkRouter {
         case .postComment:
             return .post
         case .getArticleComments:
+            return .get
+        
+        // MARK: Subscription
+        case .postSubscription:
+            return .post
+        case .deleteSubscription:
+            return .delete
+        case .getSubscribingBlogs:
+            return .get
+        case .getSubscriberBlogs:
+            return .get
+        case .getIsSubscribing:
             return .get
             
         //MARK: Like
@@ -301,7 +327,19 @@ enum NetworkRouter {
             return ["Content-Type": "application/json"]
         case .getArticleComments:
             return ["Content-Type": "application/json"]
-        
+            
+        // MARK: Subscription
+        case .postSubscription:
+            return ["Content-Type": "application/json"]
+        case .deleteSubscription:
+            return ["Content-Type": "application/json"]
+        case .getSubscribingBlogs:
+            return ["Content-Type": "application/json"]
+        case .getSubscriberBlogs:
+            return ["Content-Type": "application/json"]
+        case .getIsSubscribing:
+            return ["Content-Type": "application/json"]
+            
         //MARK: Like
         case .postLike:
             return ["Content-Type": "application/json"]

--- a/Wastory/Wastory/Repository/NetworkRouter.swift
+++ b/Wastory/Wastory/Repository/NetworkRouter.swift
@@ -38,6 +38,7 @@ enum NetworkRouter {
     case getArticlesInBlog(blogID: Int)
     case getTopArticlesInBlog(blogID: Int, sortBy: String)
     case getArticlesInBlogInCategory(blogID: Int, categoryID: Int, page: Int)
+    case getArticle(postID: Int)
     
     
     //MARK: Comment
@@ -91,6 +92,7 @@ enum NetworkRouter {
         case let .getArticlesInBlog(blogID): "/articles/blogs/\(blogID)"
         case let .getTopArticlesInBlog(blogID, sortBy): "/articles/blogs/\(blogID)/sort_by/\(sortBy)"
         case let .getArticlesInBlogInCategory(blogID: blogID, categoryID: categoryID, page: _): "/articles/blogs/\(blogID)/categories/\(categoryID)"
+        case let .getArticle(postID): "/articles/get/\(postID)"
             
         // MARK: Comment
         case let .postComment(postID): "/comments/article/\(postID)"
@@ -160,6 +162,8 @@ enum NetworkRouter {
         case .getTopArticlesInBlog:
             return .get
         case .getArticlesInBlogInCategory:
+            return .get
+        case .getArticle:
             return .get
             
         // MARK: Comment
@@ -238,6 +242,8 @@ enum NetworkRouter {
         case .getTopArticlesInBlog:
             return ["Content-Type": "application/json"]
         case .getArticlesInBlogInCategory:
+            return ["Content-Type": "application/json"]
+        case .getArticle:
             return ["Content-Type": "application/json"]
             
             

--- a/Wastory/Wastory/Repository/NetworkRouter.swift
+++ b/Wastory/Wastory/Repository/NetworkRouter.swift
@@ -32,6 +32,7 @@ enum NetworkRouter {
     case getCategoriesInBlog(blogID: Int)
     case patchCategory(categoryID: Int)
     case deleteCategory(categoryID: Int)
+    case getCategory(categoryID: Int)
     
     // MARK: Article
     case postArticle
@@ -39,7 +40,12 @@ enum NetworkRouter {
     case getTopArticlesInBlog(blogID: Int, sortBy: String)
     case getArticlesInBlogInCategory(blogID: Int, categoryID: Int, page: Int)
     case getArticle(postID: Int)
-    
+    case getArticlesTodayWastory
+    case getArticlesWeeklyWastory
+    case getArticlesHomeTopic(highHomeTopicID: Int)
+    case getArticlesOfSubscription(blogID: Int)
+    case searchArticlesInBlog(searchingWord: String, blogID: Int)
+    case searchArticles(searchingWord: String)
     
     //MARK: Comment
     case postComment(postID: Int)
@@ -86,6 +92,7 @@ enum NetworkRouter {
         case let .getCategoriesInBlog(blogID): "/categories/list/\(blogID)"
         case let .patchCategory(categoryID): "/categories/\(categoryID)"
         case let .deleteCategory(categoryID): "/categories/\(categoryID)"
+        case let .getCategory(categoryID): "/categories/\(categoryID)"
         
         // MARK: Article
         case .postArticle: "/articles/create"
@@ -93,6 +100,12 @@ enum NetworkRouter {
         case let .getTopArticlesInBlog(blogID, sortBy): "/articles/blogs/\(blogID)/sort_by/\(sortBy)"
         case let .getArticlesInBlogInCategory(blogID: blogID, categoryID: categoryID, page: _): "/articles/blogs/\(blogID)/categories/\(categoryID)"
         case let .getArticle(postID): "/articles/get/\(postID)"
+        case .getArticlesTodayWastory: "/articles/today_wastory"
+        case .getArticlesWeeklyWastory: "/articles/weekly_wastory"
+        case let .getArticlesHomeTopic(highHomeTopicID): "/articles/hometopic/\(highHomeTopicID)"
+        case let .getArticlesOfSubscription(blogID): "/articles/blogs/\(blogID)/subscription"
+        case let .searchArticlesInBlog(searchingWord, blogID): "/articles/search/\(blogID)/\(searchingWord)"
+        case let .searchArticles(searchingWord): "/articles/search/\(searchingWord)"
             
         // MARK: Comment
         case let .postComment(postID): "/comments/article/\(postID)"
@@ -153,6 +166,8 @@ enum NetworkRouter {
             return .patch
         case .deleteCategory:
             return .delete
+        case .getCategory:
+            return .get
         
         // MARK: Article
         case .postArticle:
@@ -164,6 +179,18 @@ enum NetworkRouter {
         case .getArticlesInBlogInCategory:
             return .get
         case .getArticle:
+            return .get
+        case .getArticlesTodayWastory:
+            return .get
+        case .getArticlesWeeklyWastory:
+            return .get
+        case .getArticlesHomeTopic:
+            return .get
+        case .getArticlesOfSubscription:
+            return .get
+        case .searchArticlesInBlog:
+            return .get
+        case .searchArticles:
             return .get
             
         // MARK: Comment
@@ -233,6 +260,8 @@ enum NetworkRouter {
             return ["Content-Type": "application/json"]
         case .deleteCategory:
             return ["Content-Type": "application/json"]
+        case .getCategory:
+            return ["Content-Type": "application/json"]
         
         // MARK: Article
         case .postArticle:
@@ -245,7 +274,18 @@ enum NetworkRouter {
             return ["Content-Type": "application/json"]
         case .getArticle:
             return ["Content-Type": "application/json"]
-            
+        case .getArticlesTodayWastory:
+            return ["Content-Type": "application/json"]
+        case .getArticlesWeeklyWastory:
+            return ["Content-Type": "application/json"]
+        case .getArticlesHomeTopic:
+            return ["Content-Type": "application/json"]
+        case .getArticlesOfSubscription:
+            return ["Content-Type": "application/json"]
+        case .searchArticlesInBlog:
+            return ["Content-Type": "application/json"]
+        case .searchArticles:
+            return ["Content-Type": "application/json"]
             
         // MARK: Comment
         case .postComment:

--- a/Wastory/Wastory/Repository/NetworkRouter.swift
+++ b/Wastory/Wastory/Repository/NetworkRouter.swift
@@ -61,6 +61,8 @@ enum NetworkRouter {
     case uploadImage
     case deleteImage
     
+    // MARK: HomeTopic
+    case getHomeTopicList
     
     
     var url: URL {
@@ -102,7 +104,7 @@ enum NetworkRouter {
         case let .getArticle(postID): "/articles/get/\(postID)"
         case .getArticlesTodayWastory: "/articles/today_wastory"
         case .getArticlesWeeklyWastory: "/articles/weekly_wastory"
-        case let .getArticlesHomeTopic(highHomeTopicID): "/articles/hometopic/\(highHomeTopicID)"
+        case .getArticlesHomeTopic: "/articles/hometopic/{highHomeTopicID}"
         case let .getArticlesOfSubscription(blogID): "/articles/blogs/\(blogID)/subscription"
         case let .searchArticlesInBlog(searchingWord, blogID): "/articles/search/\(blogID)/\(searchingWord)"
         case let .searchArticles(searchingWord): "/articles/search/\(searchingWord)"
@@ -120,6 +122,9 @@ enum NetworkRouter {
         case .generatePreURL: "/images/generate-presigned-urls"
         case .uploadImage: "presignedURL로 대체해서 사용합니다"
         case .deleteImage: "/images/deletes"
+            
+        // MARK: HomeTopic
+        case .getHomeTopicList: "/hometopics/list"
         }
     }
     
@@ -214,6 +219,10 @@ enum NetworkRouter {
             return .put
         case .deleteImage:
             return .delete
+            
+        // MARK: HomeTopic
+        case .getHomeTopicList:
+            return .get
         }
     }
     
@@ -307,6 +316,10 @@ enum NetworkRouter {
         case .uploadImage:
             return ["Content-Type": "image/jpeg"]
         case .deleteImage:
+            return ["Content-Type": "application/json"]
+            
+        // MARK: HomeTopic
+        case .getHomeTopicList:
             return ["Content-Type": "application/json"]
         }
     }

--- a/Wastory/Wastory/Repository/UserInfoRepository.swift
+++ b/Wastory/Wastory/Repository/UserInfoRepository.swift
@@ -23,6 +23,7 @@ final class UserInfoRepository {
     private var blogName = ""           // 블로그 이름
     private var blogID = 0              // 블로그 아이디
     private var username = ""           // 닉네임 (원래는 닉네임이 블로그에 종속되는 항목이지만 블로그가 1개로 제한됨에 따라 수정할 여지 존재)
+    private var blogMainImageURL = ""   // 블로그 메인 이미지 URL
     
     
     // 최초로 블로그를 개설했는지 App이 판단하기 위한 변수
@@ -94,6 +95,7 @@ final class UserInfoRepository {
             self.addressName = response.addressName
             self.blogName = response.blogName
             self.blogID = response.id
+            self.blogMainImageURL = response.mainImageURL ?? ""
         } catch {
             print("Error: \(error.localizedDescription)")
         }
@@ -177,6 +179,9 @@ final class UserInfoRepository {
     }
     func getUsername() -> String {
         return username
+    }
+    func getBlogMainImageURL() -> String {
+        return blogMainImageURL
     }
     
     

--- a/Wastory/Wastory/Repository/UserInfoRepository.swift
+++ b/Wastory/Wastory/Repository/UserInfoRepository.swift
@@ -128,6 +128,7 @@ final class UserInfoRepository {
             self.addressName = response.addressName
             self.blogName = response.blogName
             self.blogID = response.id
+            self.blogMainImageURL = response.mainImageURL ?? ""
         } catch {
             print("Error: \(error.localizedDescription)")
         }

--- a/Wastory/Wastory/View/BlogSheet.swift
+++ b/Wastory/Wastory/View/BlogSheet.swift
@@ -31,8 +31,7 @@ struct BlogSheet: View {
                                 .frame(height: 30)
                             
                             HStack {
-                                Image(systemName: "questionmark.text.page.fill")
-                                    .resizable()
+                                KFImageWithDefaultIcon(imageURL: UserInfoRepository.shared.getBlogMainImageURL())
                                     .aspectRatio(contentMode: .fill)
                                     .frame(width: 50, height: 50)
                                     .clipShape(Circle())
@@ -59,8 +58,7 @@ struct BlogSheet: View {
                                 .frame(height: 20)
                             
                             HStack {
-                                Image(systemName: "questionmark.text.page.fill")
-                                    .resizable()
+                                KFImageWithDefaultIcon(imageURL: UserInfoRepository.shared.getBlogMainImageURL())
                                     .aspectRatio(contentMode: .fill)
                                     .frame(width: 40, height: 40)
                                     .clipShape(

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogHeaderView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogHeaderView.swift
@@ -14,7 +14,22 @@ struct BlogHeaderView: View {
     
     var body: some View {
         ZStack{
-            Color.loadingCoralRed// 임시 배경 TODO: Blog.mainImage의 대표 색을 추출해 그라데이션으로 표현
+            ZStack(alignment: .center) {
+                GeometryReader { geometry in
+                    VStack {
+                        KFImageWithDefault(imageURL: blog.mainImageURL)
+                            .scaledToFill()
+                            .frame(width: geometry.size.width + 40 ,height: geometry.size.height + 40)
+                            .blur(radius: 20)
+                    }
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .clipped()
+                }
+            }
+            
+            //Background Dimming
+            Color.sheetOuterBackgroundColor
+            
             
             VStack(alignment: .leading, spacing: 0) {
                 Spacer()

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogHeaderView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogHeaderView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct BlogHeaderView: View {
     let blog: Blog
     
+    @Environment(\.blogViewModel) var viewModel
+    
     var body: some View {
         ZStack{
             Color.loadingCoralRed// 임시 배경 TODO: Blog.mainImage의 대표 색을 추출해 그라데이션으로 표현
@@ -25,16 +27,44 @@ struct BlogHeaderView: View {
                 Spacer()
                     .frame(height: 10)
                 
-                HStack(spacing: 5) {
-                    Text("구독자")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(Color.secondaryDarkModeLabelColor)
-                    
-                    Text("2025")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Color.primaryDarkModeLabelColor)
-                    
-                    Spacer()
+                if !viewModel.isMyBlog {
+                    HStack(spacing: 5) {
+                        Text("구독자")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Color.secondaryDarkModeLabelColor)
+                        
+                        Text("2025")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Color.primaryDarkModeLabelColor)
+                        
+                        Spacer()
+                    }
+                } else {
+                    HStack(spacing: 10) {
+                        NavigationLink(destination: SubscribeBlogView(subscribeType: .subscriber)) {
+                            HStack(spacing: 5) {
+                                Text("구독자")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundStyle(Color.secondaryDarkModeLabelColor)
+                                
+                                Text("2025")
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundStyle(Color.primaryDarkModeLabelColor)
+                            }
+                        }
+                        
+                        NavigationLink(destination: SubscribeBlogView(subscribeType: .subscribing)) {
+                            HStack(spacing: 5) {
+                                Text("구독중")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundStyle(Color.secondaryDarkModeLabelColor)
+                                
+                                Text("2025")
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundStyle(Color.primaryDarkModeLabelColor)
+                            }
+                        }
+                    }
                 }
                 
                 Spacer()
@@ -48,52 +78,81 @@ struct BlogHeaderView: View {
                 Spacer()
                     .frame(height: 17)
                 
-                HStack(spacing: 10) {
-                    Button(action: {
-                        //User.subscribingBlogID에 추가
-                    }) {
-                        ZStack {
-                            Color.white // 버튼 배경 흰색
-                            Text("구독하기")
-                                .font(.system(size: 14, weight: .light))
-                                .blendMode(.destinationOut) // 텍스트를 배경에서 투명하게 처리
+                if !viewModel.isMyBlog {
+                    HStack(spacing: 10) {
+                        Button(action: {
+                            //User.subscribingBlogID에 추가
+                        }) {
+                            ZStack {
+                                Color.white // 버튼 배경 흰색
+                                Text("구독하기")
+                                    .font(.system(size: 14, weight: .light))
+                                    .blendMode(.destinationOut) // 텍스트를 배경에서 투명하게 처리
+                            }
+                            .compositingGroup() // 블렌드 모드 적용
                         }
-                        .compositingGroup() // 블렌드 모드 적용
+                        .clipShape(RoundedRectangle(cornerRadius: 20))
+                        .frame(width: 100, height: 35)
+                        
+                        Button(action: {
+                            //방명록 View로 이동
+                        }) {
+                            Text("방명록")
+                                .font(.system(size: 14, weight: .light))
+                                .foregroundStyle(Color.primaryDarkModeLabelColor)
+                                .frame(width: 87, height: 35)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 20)
+                                        .stroke(style: StrokeStyle(lineWidth: 1))
+                                        .foregroundStyle(Color.secondaryDarkModeLabelColor)
+                                )
+                        }
+                        
+                        Spacer()
                     }
-                    .clipShape(RoundedRectangle(cornerRadius: 20))
-                    .frame(width: 100, height: 35)
-                    
-                    Button(action: {
-                        //방명록 View로 이동
-                    }) {
-                        Text("방명록")
-                            .font(.system(size: 14, weight: .light))
-                            .foregroundStyle(Color.primaryDarkModeLabelColor)
-                            .frame(width: 87, height: 35)
-                            .background(
-                                RoundedRectangle(cornerRadius: 20)
-                                    .stroke(style: StrokeStyle(lineWidth: 1))
-                                    .foregroundStyle(Color.secondaryDarkModeLabelColor)
-                            )
+                } else {
+                    HStack(spacing: 10) {
+                        
+                        NavigationLink(destination: MyBlogSettingsView()) {
+                            ZStack {
+                                Color.white // 버튼 배경 흰색
+                                Text("블로그 설정")
+                                    .font(.system(size: 14, weight: .light))
+                                    .blendMode(.destinationOut) // 텍스트를 배경에서 투명하게 처리
+                            }
+                            .compositingGroup() // 블렌드 모드 적용
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: 20))
+                        .frame(width: 110, height: 35)
+
+                        NavigationLink(destination: MyCategoryView()) {
+                            ZStack {
+                                Color.white // 버튼 배경 흰색
+                                Text("카테고리 설정")
+                                    .font(.system(size: 14, weight: .light))
+                                    .blendMode(.destinationOut) // 텍스트를 배경에서 투명하게 처리
+                            }
+                            .compositingGroup() // 블렌드 모드 적용
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: 20))
+                        .frame(width: 120, height: 35)
+                        
+                        Button(action: {
+                            //방명록 View로 이동
+                        }) {
+                            Text("방명록")
+                                .font(.system(size: 14, weight: .light))
+                                .foregroundStyle(Color.primaryDarkModeLabelColor)
+                                .frame(width: 87, height: 35)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 20)
+                                        .stroke(style: StrokeStyle(lineWidth: 1))
+                                        .foregroundStyle(Color.secondaryDarkModeLabelColor)
+                                )
+                        }
+                        
+                        Spacer()
                     }
-                    
-                    Spacer()
-                    
-                    Button(action: {
-                        //공유 / 미구현시 제거
-                    }) {
-                        Image(systemName: "square.and.arrow.up")
-                            .font(.system(size: 16, weight: .regular))
-                            .foregroundStyle(Color.primaryDarkModeLabelColor)
-                            .offset(y: -2)
-                            .frame(width: 35, height: 35)
-                            .background(
-                                RoundedRectangle(cornerRadius: 20)
-                                    .stroke(style: StrokeStyle(lineWidth: 1))
-                                    .foregroundStyle(Color.secondaryDarkModeLabelColor)
-                            )
-                    }
-                    
                 }
                 
                 Spacer()

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListCell.swift
@@ -70,8 +70,7 @@ struct BlogPostListCell: View {
                 
                 Spacer()
                 
-                Image(systemName: "questionmark.text.page.fill")
-                    .resizable()
+                KFImageWithoutDefault(imageURL: post.mainImageUrl)
                     .aspectRatio(contentMode: .fill) // 이미지비율 채워서 자르기
                     .frame(width: 70, height: 70)
                     .clipShape(

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListCell.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct BlogPostListCell: View {
     let post: Post
-    @State var blog: Blog = Blog.defaultBlog
     @State var didAppear: Bool = false
     
     @Environment(\.contentViewModel) var contentViewModel
@@ -89,16 +88,8 @@ struct BlogPostListCell: View {
         } //VStack
         
         .background(Color.white)
-        .onAppear {
-            if !didAppear {
-                Task {
-                    blog = try await contentViewModel.getBlogByID(post.blogID)
-                }
-                didAppear = true
-            }
-        }
         .overlay {
-            contentViewModel.navigateToPostViewButton(post, blog)
+            contentViewModel.navigateToPostViewButton(post.id, post.blogID)
         }
     }
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
@@ -42,7 +42,7 @@ struct BlogPostListView: View {
                         .onAppear {
                             if index == viewModel.blogPosts.count - 1 {
                                 Task {
-                                    await viewModel.getPostsInBlog()
+                                    await viewModel.getPostsInCategory()
                                 }
                             }
                         }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogPostList/BlogPostListView.swift
@@ -48,6 +48,9 @@ struct BlogPostListView: View {
                         }
                 }
             }
+            
+            Spacer()
+                .frame(height: 100)
         } //VStack
     }
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -48,7 +48,7 @@ struct BlogView: View {
                 print("refresh")
                 viewModel.resetPage()
                 Task {
-                    await viewModel.getPostsInBlog()
+                    await viewModel.getPostsInCategory()
                 }
                 Task {
                     await viewModel.getPopularBlogPosts()

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -209,7 +209,7 @@ struct BlogView: View {
                     
                     Spacer()
                     
-                    Text("\(category.articleCount ?? 0)") // 카테고리 글 개수
+                    Text("\(child.articleCount ?? 0)") // 카테고리 글 개수
                         .font(.system(size: 15, weight: .light))
                         .padding()
                 }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -174,6 +174,10 @@ struct BlogView: View {
     @ViewBuilder func CategoryButton(for category: Category, isLast: Bool, rowHeight: CGFloat) -> some View {
         Button(action: {
             viewModel.setCategory(to: category)
+            viewModel.resetPage()
+            Task {
+                await viewModel.getPostsInCategory()
+            }
             viewModel.toggleIsCategorySheetPresent()
         }) {
             HStack(spacing: 0) {
@@ -200,6 +204,10 @@ struct BlogView: View {
             
             Button(action: {
                 viewModel.setCategory(to: child)
+                viewModel.resetPage()
+                Task {
+                    await viewModel.getPostsInCategory()
+                }
                 viewModel.toggleIsCategorySheetPresent()
             }) {
                 HStack(spacing: 0) {

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -127,8 +127,18 @@ struct BlogView: View {
                 }
                 Task {
                     await viewModel.getCategories()
-                    if let foundCategory = viewModel.categories.first(where: { $0.id == categoryID }) {
-                        viewModel.selectedCategory = foundCategory
+                    for category in viewModel.categories {
+                        if category.id == categoryID {
+                            viewModel.selectedCategory = category
+                            break
+                        } else {
+                            for child in category.children ?? [] {
+                                if child.id == categoryID {
+                                    viewModel.selectedCategory = child
+                                    break
+                                }
+                            }
+                        }
                     }
                     await viewModel.getPostsInCategory()
                 }

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct BlogView: View {
     let blogID: Int
+    var categoryID: Int = -1
     @State var viewModel = BlogViewModel()
     @Environment(\.dismiss) private var dismiss
     @Environment(\.contentViewModel) var contentViewModel
@@ -121,13 +122,14 @@ struct BlogView: View {
                 await viewModel.initBlog(blogID)
                 viewModel.resetPage()
                 Task {
-                    await viewModel.getPostsInBlog()
-                }
-                Task {
                     await viewModel.getPopularBlogPosts()
                 }
                 Task {
                     await viewModel.getCategories()
+                    if let foundCategory = viewModel.categories.first(where: { $0.id == categoryID }) {
+                        viewModel.selectedCategory = foundCategory
+                    }
+                    await viewModel.getPostsInCategory()
                 }
             }
         }
@@ -200,7 +202,7 @@ struct BlogView: View {
         
         
         //TODO: Children 추가기능 구현
-        ForEach(Array(category.children.enumerated()), id: \.offset) { index, child in
+        ForEach(Array((category.children ?? []).enumerated()), id: \.offset) { index, child in
             
             Button(action: {
                 viewModel.setCategory(to: child)

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct BlogView: View {
-    let blog: Blog
+    let blogID: Int
     @State var viewModel = BlogViewModel()
     @Environment(\.dismiss) private var dismiss
     @Environment(\.contentViewModel) var contentViewModel
@@ -20,7 +20,7 @@ struct BlogView: View {
             ScrollView(.vertical) {
                 VStack(spacing: 0) {
                     
-                    BlogHeaderView(blog: blog)
+                    BlogHeaderView(blog: viewModel.blog)
                     
                     GeometryReader { geometry in
                         Color.clear
@@ -35,7 +35,7 @@ struct BlogView: View {
                     
                     
                     // 인기글 TODO: 인기글 모두보기 View
-                    PopularBlogPostListView(blog: blog)
+                    PopularBlogPostListView(blog: viewModel.blog)
                     
                     // 카테고리 별 글 TODO: 카테고리 선택 sheet 및 카테고리 별로 분류
                     BlogPostListView()
@@ -117,22 +117,24 @@ struct BlogView: View {
             
         } //ZStack
         .onAppear {
-            viewModel.initBlog(blog)
-            viewModel.resetPage()
             Task {
-                await viewModel.getPostsInBlog()
-            }
-            Task {
-                await viewModel.getPopularBlogPosts()
-            }
-            Task {
-                await viewModel.getCategories()
+                await viewModel.initBlog(blogID)
+                viewModel.resetPage()
+                Task {
+                    await viewModel.getPostsInBlog()
+                }
+                Task {
+                    await viewModel.getPopularBlogPosts()
+                }
+                Task {
+                    await viewModel.getCategories()
+                }
             }
         }
         .environment(\.blogViewModel, viewModel)
         .ignoresSafeArea(edges: .all)
         // MARK: NavBar
-        .navigationTitle(viewModel.getIsNavTitleHidden() ? "" : blog.blogName)
+        .navigationTitle(viewModel.getIsNavTitleHidden() ? "" : viewModel.blog.blogName)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(viewModel.getIsNavTitleHidden() ? .hidden : .visible, for: .navigationBar)
         .toolbarBackground(Color.white, for: .navigationBar)

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -74,7 +74,7 @@ struct BlogView: View {
                     if viewModel.isCategorySheetPresent {
                         let sheetTopSpace: CGFloat = 30
                         let sheetRowHeight: CGFloat = 60
-                        let sheetBottomSpace: CGFloat = 30
+                        let sheetBottomSpace: CGFloat = 30 + (isMainTab ? 100 : 0)
                         let sheetTitleHeight: CGFloat = 50
                         let sheetHeight: CGFloat = UIScreen.main.bounds.height * 0.6
                         
@@ -101,8 +101,6 @@ struct BlogView: View {
                                         .frame(height: sheetBottomSpace)
                                 }
                                 
-                                Spacer()
-                                    .frame(height: 100)
                             }
                             .frame(height: sheetHeight)
                             .background(Color.white)

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct BlogView: View {
     let blogID: Int
     var categoryID: Int = -1
+    var isMainTab: Bool = false
     @State var viewModel = BlogViewModel()
     @Environment(\.dismiss) private var dismiss
     @Environment(\.contentViewModel) var contentViewModel
@@ -100,6 +101,8 @@ struct BlogView: View {
                                         .frame(height: sheetBottomSpace)
                                 }
                                 
+                                Spacer()
+                                    .frame(height: 100)
                             }
                             .frame(height: sheetHeight)
                             .background(Color.white)
@@ -140,6 +143,7 @@ struct BlogView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(viewModel.getIsNavTitleHidden() ? .hidden : .visible, for: .navigationBar)
         .toolbarBackground(Color.white, for: .navigationBar)
+        .toolbarVisibility(isMainTab ? .hidden : .visible, for: .navigationBar)
         .toolbar{
             ToolbarItem(placement: .navigationBarTrailing) {
                 HStack(spacing: 20) {

--- a/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/BlogView.swift
@@ -162,9 +162,9 @@ struct BlogView: View {
                     
                     Button(action: {
                         //차단하기 신고하기 sheet present
+                        //if myBlog -> blogSheet present
                     }) {
-                        Image(systemName: "questionmark.text.page.fill")
-                            .resizable()
+                        KFImageWithDefaultIcon(imageURL: viewModel.blog.mainImageURL)
                             .scaledToFill()
                             .clipShape(Circle())
                             .frame(width: 30, height: 30)

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostCell.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct PopularBlogPostCell: View {
     let post: Post
-    @State var blog: Blog = Blog.defaultBlog
     @State var didAppear: Bool = false
     
     @Environment(\.contentViewModel) var contentViewModel
@@ -80,16 +79,8 @@ struct PopularBlogPostCell: View {
             
         } //VStack
         .background(Color.white)
-        .onAppear {
-            if !didAppear {
-                Task {
-                    blog = try await contentViewModel.getBlogByID(post.blogID)
-                }
-                didAppear = true
-            }
-        }
         .overlay {
-            contentViewModel.navigateToPostViewButton(post, blog)
+            contentViewModel.navigateToPostViewButton(post.id, post.blogID)
         }
     }
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostList/PopularBlogPostCell.swift
@@ -65,8 +65,8 @@ struct PopularBlogPostCell: View {
                 
                 Spacer()
                 
-                Image(systemName: "questionmark.text.page.fill")
-                    .resizable()
+                
+                KFImageWithoutDefault(imageURL: post.mainImageUrl)
                     .aspectRatio(contentMode: .fill) // 이미지비율 채워서 자르기
                     .frame(width: 50, height: 50)
                     .clipShape(

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetCell.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct PopularBlogPostSheetCell: View {
     let post: Post
     let index: Int
-    @State var blog: Blog = Blog.defaultBlog
     @State var didAppear: Bool = false
     
     @Bindable var viewModel: PopularBlogPostSheetViewModel
@@ -90,16 +89,8 @@ struct PopularBlogPostSheetCell: View {
             
         } //VStack
         .background(Color.white)
-        .onAppear {
-            if !didAppear {
-                Task {
-                    blog = try await contentViewModel.getBlogByID(post.blogID)
-                }
-                didAppear = true
-            }
-        }
         .overlay {
-            contentViewModel.navigateToPostViewButton(post, blog)
+            contentViewModel.navigateToPostViewButton(post.id, post.blogID)
         }
     }
 }

--- a/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetCell.swift
+++ b/Wastory/Wastory/View/ContentView/BlogView/PopularBlogPost/PopularBlogPostSheet/PopularBlogPostSheetCell.swift
@@ -74,8 +74,8 @@ struct PopularBlogPostSheetCell: View {
                 
                 Spacer()
                 
-                Image(systemName: "questionmark.text.page.fill")
-                    .resizable()
+                
+                KFImageWithoutDefault(imageURL: post.mainImageUrl)
                     .aspectRatio(contentMode: .fill) // 이미지비율 채워서 자르기
                     .frame(width: 50, height: 50)
                     .clipShape(

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Kingfisher
 
 struct CommentCell: View {
     var comment: Comment
@@ -33,12 +34,22 @@ struct CommentCell: View {
                 
                 
                 
-                contentViewModel.navigateToBlogViewButton(tempBlog().id) {
-                    Image(systemName: "questionmark.text.page.fill")
-                        .resizable()
-                        .scaledToFill()
-                        .clipShape(Circle())
-                        .frame(width: 40, height: 40)
+                contentViewModel.navigateToBlogViewButton(comment.blogID) {
+                    VStack(spacing: 0) {
+                        if comment.blogMainImageURL ?? "" == "" {
+                            Image("defaultImage")
+                                .resizable()
+                                .scaledToFill()
+                                .clipShape(Circle())
+                                .frame(width: 40, height: 40)
+                        } else {
+                            KFImage(URL(string: comment.blogMainImageURL!))
+                                .resizable()
+                                .scaledToFill()
+                                .clipShape(Circle())
+                                .frame(width: 40, height: 40)
+                        }
+                    }
                 }
                 
                 Spacer()
@@ -47,7 +58,7 @@ struct CommentCell: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 5) {
                         contentViewModel.navigateToBlogViewButton(tempBlog().id) {
-                            Text("유저 이름")
+                            Text(comment.userName)
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundStyle(Color.primaryLabelColor)
                         }

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
@@ -32,7 +32,7 @@ struct CommentCell: View {
                 
                 
                 
-                contentViewModel.navigateToBlogViewButton(tempBlog()) {
+                contentViewModel.navigateToBlogViewButton(tempBlog().id) {
                     Image(systemName: "questionmark.text.page.fill")
                         .resizable()
                         .scaledToFill()
@@ -45,7 +45,7 @@ struct CommentCell: View {
                 
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 5) {
-                        contentViewModel.navigateToBlogViewButton(tempBlog()) {
+                        contentViewModel.navigateToBlogViewButton(tempBlog().id) {
                             Text("유저 이름")
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundStyle(Color.primaryLabelColor)

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
@@ -35,21 +35,10 @@ struct CommentCell: View {
                 
                 
                 contentViewModel.navigateToBlogViewButton(comment.blogID) {
-                    VStack(spacing: 0) {
-                        if comment.blogMainImageURL ?? "" == "" {
-                            Image("defaultImage")
-                                .resizable()
-                                .scaledToFill()
-                                .clipShape(Circle())
-                                .frame(width: 40, height: 40)
-                        } else {
-                            KFImage(URL(string: comment.blogMainImageURL!))
-                                .resizable()
-                                .scaledToFill()
-                                .clipShape(Circle())
-                                .frame(width: 40, height: 40)
-                        }
-                    }
+                    KFImageWithDefault(imageURL: comment.blogMainImageURL)
+                        .scaledToFill()
+                        .clipShape(Circle())
+                        .frame(width: 40, height: 40)
                 }
                 
                 Spacer()

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
@@ -11,7 +11,7 @@ import Kingfisher
 struct CommentCell: View {
     var comment: Comment
     let isChild: Bool
-    let rootCommentId: Int
+    let rootComment: Comment
     
     @Bindable var viewModel: CommentViewModel
     
@@ -77,7 +77,7 @@ struct CommentCell: View {
                         
                         Button(action: {
                             viewModel.updateIsTextFieldFocused()
-                            viewModel.setTargetCommentID(to: rootCommentId)
+                            viewModel.setTargetCommentID(to: rootComment)
                         }) {
                             Text("답글")
                                 .font(.system(size: 15, weight: .bold))
@@ -109,7 +109,7 @@ struct CommentCell: View {
             
             if !isChild {
                 ForEach(comment.children ?? []) { child in
-                    CommentCell(comment: child, isChild: true, rootCommentId: comment.id, viewModel: viewModel)
+                    CommentCell(comment: child, isChild: true, rootComment: comment, viewModel: viewModel)
                 }
             }
         }//VStack1

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CommentCell: View {
     var comment: Comment
     let isChild: Bool
+    let rootCommentId: Int
     
     @Bindable var viewModel: CommentViewModel
     
@@ -76,7 +77,7 @@ struct CommentCell: View {
                         
                         Button(action: {
                             viewModel.updateIsTextFieldFocused()
-                            viewModel.setTargetCommentID(to: comment.id)
+                            viewModel.setTargetCommentID(to: rootCommentId)
                         }) {
                             Text("답글")
                                 .font(.system(size: 15, weight: .bold))
@@ -108,7 +109,7 @@ struct CommentCell: View {
             
             if !isChild {
                 ForEach(comment.children ?? []) { child in
-                    CommentCell(comment: child, isChild: true, viewModel: viewModel)
+                    CommentCell(comment: child, isChild: true, rootCommentId: comment.id, viewModel: viewModel)
                 }
             }
         }//VStack1

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
@@ -56,7 +56,7 @@ struct CommentView: View {
                     
                     // MARK: 댓글List
                     ForEach(viewModel.comments) { comment in
-                        CommentCell(comment: comment, isChild: false, rootCommentId: comment.id, viewModel: viewModel)
+                        CommentCell(comment: comment, isChild: false, rootComment: comment, viewModel: viewModel)
                     }
                 }
             }
@@ -86,7 +86,7 @@ struct CommentView: View {
                 
                 if viewModel.isTargetToComment {
                     HStack(spacing: 0) {
-                        Text("유저이름")
+                        Text(viewModel.targetComment!.userName)
                             .font(.system(size: 13, weight: .semibold))
                             .foregroundStyle(Color.primaryLabelColor)
                         
@@ -146,6 +146,7 @@ struct CommentView: View {
                             Task {
                                 await viewModel.postComment()
                                 viewModel.resetPage()
+                                viewModel.resetTargetCommentID()
                                 viewModel.resetWritingCommentText()
                                 await viewModel.getComments()
                                 

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
@@ -56,7 +56,7 @@ struct CommentView: View {
                     
                     // MARK: 댓글List
                     ForEach(viewModel.comments) { comment in
-                        CommentCell(comment: comment, isChild: false, viewModel: viewModel)
+                        CommentCell(comment: comment, isChild: false, rootCommentId: comment.id, viewModel: viewModel)
                     }
                 }
             }

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
@@ -146,7 +146,9 @@ struct CommentView: View {
                             Task {
                                 await viewModel.postComment()
                                 viewModel.resetPage()
+                                viewModel.resetWritingCommentText()
                                 await viewModel.getComments()
+                                
                             }
                         }) {
                             Text("등록")

--- a/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
@@ -55,10 +55,25 @@ struct CommentView: View {
                     
                     
                     // MARK: 댓글List
-                    ForEach(viewModel.comments) { comment in
+                    ForEach(Array(viewModel.comments.enumerated()), id: \.offset) { index, comment in
                         CommentCell(comment: comment, isChild: false, rootComment: comment, viewModel: viewModel)
+                            .onAppear {
+                                if index == viewModel.comments.count - 1 {
+                                    Task {
+                                        await viewModel.getComments()
+                                    }
+                                }
+                            }
                     }
                 }
+            }
+        }
+        .refreshable {
+            viewModel.resetPage()
+            viewModel.resetTargetCommentID()
+            viewModel.resetWritingCommentText()
+            Task {
+                await viewModel.getComments()
             }
         }
         // MARK: NavBar
@@ -149,7 +164,6 @@ struct CommentView: View {
                                 viewModel.resetTargetCommentID()
                                 viewModel.resetWritingCommentText()
                                 await viewModel.getComments()
-                                
                             }
                         }) {
                             Text("등록")

--- a/Wastory/Wastory/View/ContentView/PostView/BlogPopularPostGrid/BlogPopularPostGridCell.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/BlogPopularPostGrid/BlogPopularPostGridCell.swift
@@ -14,7 +14,7 @@ struct BlogPopularPostGridCell: View {
     @Environment(\.postViewModel) var viewModel
     
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
             GeometryReader { geometry in
                 Color.clear
                     .onAppear() {
@@ -36,6 +36,8 @@ struct BlogPopularPostGridCell: View {
                 .font(.system(size: 18, weight: .light))
                 .foregroundStyle(Color.primaryLabelColor)
                 .lineLimit(2)
+            
+            Spacer()
         } //VStack
         .padding(.vertical, 10)
         

--- a/Wastory/Wastory/View/ContentView/PostView/BlogPopularPostGrid/BlogPopularPostGridCell.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/BlogPopularPostGrid/BlogPopularPostGridCell.swift
@@ -23,8 +23,7 @@ struct BlogPopularPostGridCell: View {
             }
             .frame(height: 0)
             
-            Image(systemName: "questionmark.text.page.fill")
-                .resizable()
+            KFImageWithDefault(imageURL: post.mainImageUrl)
                 .scaledToFill()
                 .frame(width: viewModel.getBlogPopularPostGridCellWidth() ,height: viewModel.getBlogPopularPostGridCellWidth() * 5 / 8)
                 .clipped()

--- a/Wastory/Wastory/View/ContentView/PostView/BlogPopularPostGrid/BlogPopularPostGridCell.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/BlogPopularPostGrid/BlogPopularPostGridCell.swift
@@ -42,7 +42,7 @@ struct BlogPopularPostGridCell: View {
         
         .background(Color.white)
         .overlay {
-            contentViewModel.navigateToPostViewButton(post, viewModel.blog!)
+            contentViewModel.navigateToPostViewButton(post.id, viewModel.blog.id)
         }
     }
 }

--- a/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListCell.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListCell.swift
@@ -71,8 +71,7 @@ struct CategoryPostListCell: View {
                 
                 Spacer()
                 
-                Image(systemName: "questionmark.text.page.fill")
-                    .resizable()
+                KFImageWithoutDefault(imageURL: post.mainImageUrl)
                     .aspectRatio(contentMode: .fill) // 이미지비율 채워서 자르기
                     .frame(width: 100, height: 100)
                     .clipped()

--- a/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListCell.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListCell.swift
@@ -87,7 +87,7 @@ struct CategoryPostListCell: View {
         
         .background(Color.white)
         .overlay {
-            contentViewModel.navigateToPostViewButton(post, viewModel.blog!)
+            contentViewModel.navigateToPostViewButton(post.id, viewModel.blog.id)
         }
     }
 }

--- a/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListView.swift
@@ -31,12 +31,10 @@ struct CategoryPostListView: View {
                 
                 Spacer()
                 
-                if let _ = viewModel.blog {
-                    contentViewModel.navigateToBlogViewButton(viewModel.blog!) {
-                        Text("더보기")
-                            .font(.system(size: 14, weight: .light))
-                            .foregroundStyle(Color.secondaryLabelColor)
-                    }
+                contentViewModel.navigateToBlogViewButton(viewModel.blog.id) {
+                    Text("더보기")
+                        .font(.system(size: 14, weight: .light))
+                        .foregroundStyle(Color.secondaryLabelColor)
                 }
             }
             .padding(.horizontal, 20)

--- a/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListView.swift
@@ -21,7 +21,7 @@ struct CategoryPostListView: View {
             
             
             HStack(alignment: .center, spacing: 6) {
-                Text("카테고리 (미선택 시 : 이 블로그)")
+                Text(viewModel.post.categoryID == -1 ? "이 블로그" : viewModel.categoryName)
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(Color.loadingCoralRed)
                 
@@ -31,7 +31,7 @@ struct CategoryPostListView: View {
                 
                 Spacer()
                 
-                contentViewModel.navigateToBlogViewButton(viewModel.blog.id) {
+                contentViewModel.navigateToBlogViewButton(viewModel.blog.id, viewModel.post.categoryID) {
                     Text("더보기")
                         .font(.system(size: 14, weight: .light))
                         .foregroundStyle(Color.secondaryLabelColor)

--- a/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/CategoryPostList/CategoryPostListView.swift
@@ -21,7 +21,7 @@ struct CategoryPostListView: View {
             
             
             HStack(alignment: .center, spacing: 6) {
-                Text(viewModel.post.categoryID == -1 ? "이 블로그" : viewModel.categoryName)
+                Text(viewModel.post.categoryID == 0 ? "이 블로그" : viewModel.categoryName)
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(Color.loadingCoralRed)
                 

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -164,10 +164,13 @@ struct PostView: View {
                     .padding(.bottom, 30)
                     .background(Color.blogDetailBackgroundColor)
                     
+                    if !viewModel.categoryBlogPosts.isEmpty {
+                        CategoryPostListView()
+                    }
                     
-                    CategoryPostListView()
-                    
-                    BlogPopularPostGridView()
+                    if !viewModel.popularBlogPosts.isEmpty {
+                        BlogPopularPostGridView()
+                    }
                     
                     VStack(spacing: 10) {
                         HStack {

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct PostView: View {
-    let post: Post
-    let blog: Blog
+    let postID: Int
+    let blogID: Int
     @State private var viewModel = PostViewModel()
     @Environment(\.dismiss) private var dismiss
     @Environment(\.contentViewModel) var contentViewModel

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -38,7 +38,7 @@ struct PostView: View {
                             .frame(height: 100)
                         
                         // MARK: 카테고리 버튼
-                        contentViewModel.navigateToBlogViewButton(blog) {
+                        contentViewModel.navigateToBlogViewButton(blogID) {
                             Text("카테고리 없음")
                                 .font(.system(size: 16, weight: .regular))
                                 .foregroundStyle(Color.primaryLabelColor)
@@ -60,7 +60,7 @@ struct PostView: View {
                             .frame(height: 10)
                         
                         // MARK: Title
-                        Text(post.title)
+                        Text(viewModel.post.title)
                             .font(.system(size: 34, weight: .medium))
                             .foregroundStyle(Color.primaryLabelColor)
                             .padding(.horizontal, 20)
@@ -70,7 +70,7 @@ struct PostView: View {
                         
                         // MARK: 블로그 이름 . 작성일자
                         HStack(spacing: 5) {
-                            Text(blog.blogName)
+                            Text(viewModel.blog.blogName)
                                 .font(.system(size: 14, weight: .light))
                                 .foregroundStyle(Color.secondaryLabelColor)
                             
@@ -78,7 +78,7 @@ struct PostView: View {
                                 .font(.system(size: 3, weight: .regular))
                                 .foregroundStyle(Color.middleDotColor)
                             
-                            Text("\(timeFormatter(from: post.createdAt))")
+                            Text("\(timeFormatter(from: viewModel.post.createdAt))")
                                 .font(.system(size: 12, weight: .regular))
                                 .foregroundStyle(Color.secondaryLabelColor)
                         }
@@ -88,7 +88,7 @@ struct PostView: View {
                             .frame(height: 60)
                         
                         // MARK: Content
-                        Text(post.content ?? "")
+                        Text(viewModel.post.content ?? "")
                             .font(.system(size: 20, weight: .light))
                             .foregroundStyle(Color.primaryLabelColor)
                             .padding(.horizontal, 20)
@@ -109,8 +109,8 @@ struct PostView: View {
                     //Blog 세부설명 및 구독버튼
                     HStack(alignment: .top, spacing: 20) {
                         VStack(alignment: .leading, spacing: 0) {
-                            contentViewModel.navigateToBlogViewButton(blog) {
-                                Text(blog.blogName)
+                            contentViewModel.navigateToBlogViewButton(blogID) {
+                                Text(viewModel.blog.blogName)
                                     .font(.system(size: 18, weight: .light))
                                     .foregroundStyle(Color.primaryLabelColor)
                                     .multilineTextAlignment(.leading)
@@ -120,8 +120,8 @@ struct PostView: View {
                             Spacer()
                                 .frame(height: 5)
                             
-                            contentViewModel.navigateToBlogViewButton(blog) {
-                                Text(blog.description)
+                            contentViewModel.navigateToBlogViewButton(blogID) {
+                                Text(viewModel.blog.description)
                                     .font(.system(size: 14, weight: .light))
                                     .foregroundStyle(Color.secondaryLabelColor)
                                     .lineLimit(3)
@@ -149,7 +149,7 @@ struct PostView: View {
                         
                         Spacer()
                         
-                        contentViewModel.navigateToBlogViewButton(blog) {
+                        contentViewModel.navigateToBlogViewButton(blogID) {
                             Image(systemName: "questionmark.text.page.fill")
                                 .resizable()
                                 .aspectRatio(contentMode: .fill) // 이미지비율 채워서 자르기
@@ -193,15 +193,17 @@ struct PostView: View {
         .environment(\.postViewModel, viewModel)
         //MARK: Networking
         .onAppear {
-            viewModel.initContent(post, blog)
             Task {
-                await viewModel.getPostsInBlogInCategory()
-            }
-            Task {
-                await viewModel.getPopularBlogPosts()
-            }
-            Task {
-                await viewModel.getIsLiked()
+                await viewModel.initContent(postID, blogID)
+                Task {
+                    await viewModel.getPostsInBlogInCategory()
+                }
+                Task {
+                    await viewModel.getPopularBlogPosts()
+                }
+                Task {
+                    await viewModel.getIsLiked()
+                }
             }
         }
         .ignoresSafeArea(edges: .all)
@@ -211,7 +213,7 @@ struct PostView: View {
         .toolbarVisibility(viewModel.getIsNavTitleHidden() ? .hidden : .visible, for: .navigationBar)
         .toolbar{
             ToolbarItem(placement: .navigationBarTrailing) {
-                contentViewModel.navigateToBlogViewButton(blog) {
+                contentViewModel.navigateToBlogViewButton(blogID) {
                     Image(systemName: "questionmark.text.page.fill")
                         .resizable()
                         .scaledToFill()
@@ -250,7 +252,7 @@ struct PostView: View {
                                 .font(.system(size: 20, weight: .light))
                                 .foregroundStyle(viewModel.isLiked ? Color.loadingCoralRed : Color.primaryLabelColor)
                             
-                            Text("\((viewModel.post ?? Post.defaultPost).likeCount)")
+                            Text("\(viewModel.post.likeCount)")
                                 .font(.system(size: 16, weight: .light))
                                 .foregroundStyle(Color.bottomBarLabelColor)
                         }
@@ -260,13 +262,13 @@ struct PostView: View {
                         .frame(width: 25)
                     
                     //댓글 버튼
-                    NavigationLink(destination: CommentView(postID: post.id)) {
+                    NavigationLink(destination: CommentView(postID: postID)) {
                         HStack(spacing: 3) {
                             Image(systemName: "text.bubble")
                                 .font(.system(size: 20, weight: .light))
                                 .foregroundStyle(Color.primaryLabelColor)
                             
-                            Text("\(post.commentCount)")
+                            Text("\(viewModel.post.commentCount)")
                                 .font(.system(size: 16, weight: .light))
                                 .foregroundStyle(Color.bottomBarLabelColor)
                         }

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -38,8 +38,8 @@ struct PostView: View {
                             .frame(height: 100)
                         
                         // MARK: 카테고리 버튼
-                        contentViewModel.navigateToBlogViewButton(blogID) {
-                            Text("카테고리 없음")
+                        contentViewModel.navigateToBlogViewButton(blogID, viewModel.post.categoryID) {
+                            Text(viewModel.post.categoryID == -1 ? "카테고리 없음" : viewModel.categoryName)
                                 .font(.system(size: 16, weight: .regular))
                                 .foregroundStyle(Color.primaryLabelColor)
                                 .background(

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -217,8 +217,7 @@ struct PostView: View {
         .toolbar{
             ToolbarItem(placement: .navigationBarTrailing) {
                 contentViewModel.navigateToBlogViewButton(blogID) {
-                    Image(systemName: "questionmark.text.page.fill")
-                        .resizable()
+                    KFImageWithDefaultIcon(imageURL: viewModel.blog.mainImageURL)
                         .scaledToFill()
                         .clipShape(Circle())
                         .frame(width: 30, height: 30)

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -150,8 +150,7 @@ struct PostView: View {
                         Spacer()
                         
                         contentViewModel.navigateToBlogViewButton(blogID) {
-                            Image(systemName: "questionmark.text.page.fill")
-                                .resizable()
+                            KFImageWithDefault(imageURL: viewModel.blog.mainImageURL)
                                 .aspectRatio(contentMode: .fill) // 이미지비율 채워서 자르기
                                 .frame(width: 60, height: 60)
                                 .clipShape(

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -39,7 +39,7 @@ struct PostView: View {
                         
                         // MARK: 카테고리 버튼
                         contentViewModel.navigateToBlogViewButton(blogID, viewModel.post.categoryID) {
-                            Text(viewModel.post.categoryID == -1 ? "카테고리 없음" : viewModel.categoryName)
+                            Text(viewModel.post.categoryID == 0 ? "카테고리 없음" : viewModel.categoryName)
                                 .font(.system(size: 16, weight: .regular))
                                 .foregroundStyle(Color.primaryLabelColor)
                                 .background(

--- a/Wastory/Wastory/View/FeedView/BasicCells/BasicBlogCell.swift
+++ b/Wastory/Wastory/View/FeedView/BasicCells/BasicBlogCell.swift
@@ -13,8 +13,7 @@ struct BasicBlogCell: View {
     
     var body: some View {
         HStack(alignment: .center, spacing: 0) {
-            Image(systemName: "questionmark.text.page.fill")
-                .resizable()
+            KFImageWithDefaultIcon(imageURL: blog.mainImageURL)
                 .aspectRatio(contentMode: .fill) // 이미지비율 채워서 자르기
                 .frame(width: 60, height: 60)
                 .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -57,7 +56,7 @@ struct BasicBlogCell: View {
         .padding(20)
         .background(Color.white)
         .overlay {
-            contentViewModel.navigateToBlogViewButton(tempBlog().id) {
+            contentViewModel.navigateToBlogViewButton(blog.id) {
                 Rectangle()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .foregroundStyle(Color.clear)

--- a/Wastory/Wastory/View/FeedView/BasicCells/BasicBlogCell.swift
+++ b/Wastory/Wastory/View/FeedView/BasicCells/BasicBlogCell.swift
@@ -57,7 +57,7 @@ struct BasicBlogCell: View {
         .padding(20)
         .background(Color.white)
         .overlay {
-            contentViewModel.navigateToBlogViewButton(tempBlog()) {
+            contentViewModel.navigateToBlogViewButton(tempBlog().id) {
                 Rectangle()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .foregroundStyle(Color.clear)

--- a/Wastory/Wastory/View/FeedView/BasicCells/BasicPostCell.swift
+++ b/Wastory/Wastory/View/FeedView/BasicCells/BasicPostCell.swift
@@ -11,7 +11,6 @@ import SwiftUI
 // [제목, 내용 및 이미지, 좋아요 수, 댓글 수, 업로드 시간, 업로드된 블로그] 정보가 필요.
 struct BasicPostCell: View {
     let post: Post
-    @State var blog: Blog = Blog.defaultBlog
     @State var didAppear: Bool = false
     
     @Environment(\.contentViewModel) var contentViewModel
@@ -69,7 +68,7 @@ struct BasicPostCell: View {
                 }
                 
                 //MARK: posted blog info
-                contentViewModel.navigateToBlogViewButton(blog) {
+                contentViewModel.navigateToBlogViewButton(post.blogID) {
                     HStack(alignment: .center, spacing: 9) {
                         //blog image
                         Image(systemName: "questionmark.app.dashed")
@@ -80,7 +79,7 @@ struct BasicPostCell: View {
                             .cornerRadius(5)
                         
                         //blog name
-                        Text(blog.blogName)
+                        Text(post.blogName ?? "")
                             .font(.system(size: 14, weight: .light))
                             .foregroundStyle(Color.secondaryLabelColor)
                     }
@@ -98,22 +97,14 @@ struct BasicPostCell: View {
                 .frame(width: 100, height: 100)
                 .clipped()
                 .overlay {
-                    contentViewModel.navigateToPostViewButton(post, blog)
+                    contentViewModel.navigateToPostViewButton(post.id, post.blogID)
                 }
                 
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 22)
-        .onAppear {
-            if !didAppear {
-                Task {
-                    blog = try await contentViewModel.getBlogByID(post.blogID)
-                }
-                didAppear = true
-            }
-        }
         .background {
-            contentViewModel.navigateToPostViewButton(post, blog)
+            contentViewModel.navigateToPostViewButton(post.id, post.blogID)
         }
     }
 }

--- a/Wastory/Wastory/View/FeedView/BasicCells/BasicPostCell.swift
+++ b/Wastory/Wastory/View/FeedView/BasicCells/BasicPostCell.swift
@@ -71,8 +71,7 @@ struct BasicPostCell: View {
                 contentViewModel.navigateToBlogViewButton(post.blogID) {
                     HStack(alignment: .center, spacing: 9) {
                         //blog image
-                        Image(systemName: "questionmark.app.dashed")
-                            .resizable()
+                        KFImageWithDefaultIcon(imageURL: post.blogMainImageURL)
                             .frame(width: 20, height: 20)
                             .background(Color.secondaryLabelColor.opacity(0.3))
                             .clipped()
@@ -91,8 +90,7 @@ struct BasicPostCell: View {
             
             //MARK: content Image
             //글 내용에 이미지가 없을 경우 표시하지 않음
-            Image(systemName: "questionmark.text.page.fill")
-                .resizable()
+            KFImageWithoutDefault(imageURL: post.mainImageUrl)
                 .aspectRatio(contentMode: .fill) // 이미지비율 채워서 자르기
                 .frame(width: 100, height: 100)
                 .clipped()

--- a/Wastory/Wastory/View/FeedView/FeedView.swift
+++ b/Wastory/Wastory/View/FeedView/FeedView.swift
@@ -97,30 +97,6 @@ struct FeedView: View {
                 }
                 .padding(.trailing, 22)
                 
-                Button {
-                    Task {
-                        do {
-                            let response = try await NetworkRepository.shared.getArticlesInBlog(blogID: UserInfoRepository.shared.getBlogID(), page: 1)
-                            viewModel.posts = response
-                            print("성공")
-                        }
-                        catch let DecodingError.dataCorrupted(context) {
-                           print("디코딩 실패 - 데이터 손상: \(context.debugDescription)")
-                       } catch let DecodingError.keyNotFound(key, context) {
-                           print("디코딩 실패 - 키 없음: \(key.stringValue), \(context.debugDescription)")
-                       } catch let DecodingError.typeMismatch(type, context) {
-                           print("디코딩 실패 - 타입 불일치: \(type), \(context.debugDescription)")
-                       } catch let DecodingError.valueNotFound(value, context) {
-                           print("디코딩 실패 - 값 없음: \(value), \(context.debugDescription)")
-                       } catch {
-                           print("알 수 없는 오류: \(error.localizedDescription)")
-                       }
-                    }
-                } label: {
-                    Text("버버버튼튼튼")
-                        .frame(width: 100, height: 100)
-                }
-                
                 //MARK: PostList
                 LazyVStack(spacing: 0) {
                     ForEach(Array(viewModel.posts.enumerated()), id: \.offset) { index, post in
@@ -131,10 +107,16 @@ struct FeedView: View {
                 }
             }
         }
+        //MARK: Network
         .onAppear {
             Task {
-                let response = try await NetworkRepository.shared.getArticlesInBlog(blogID: UserInfoRepository.shared.getBlogID(), page: 1)
-                viewModel.posts = response
+                await viewModel.getPosts()
+            }
+        }
+        .refreshable {
+            viewModel.resetPage()
+            Task {
+                await viewModel.getPosts()
             }
         }
         

--- a/Wastory/Wastory/View/HomeView/CategoryPopularPostView.swift
+++ b/Wastory/Wastory/View/HomeView/CategoryPopularPostView.swift
@@ -32,8 +32,8 @@ struct CategoryPopularPostView: View {
                 HStack(spacing: 5) {
                     Spacer()
                         .frame(width: 20)
-                    ForEach(viewModel.categoryList, id: \.self) { category in
-                        categoryButton(category: category, isSelected: viewModel.selectedCategory == category)
+                    ForEach(viewModel.categoryList) { category in
+                        categoryButton(category: category, isSelected: viewModel.selectedCategory.id == category.id)
                     }
                     Spacer()
                         .frame(width: 20)
@@ -43,28 +43,30 @@ struct CategoryPopularPostView: View {
             .zIndex(1)
             
             LazyVStack(spacing: 0) {
-                ForEach(Array(viewModel.categoryPopularPostItems[0..<2].enumerated()), id: \.offset) { index, item in
-                    HomeBigPostListCell()
+                ForEach(Array(viewModel.categoryPopularPostItems.prefix(2).enumerated()), id: \.offset) { index, item in
+                    if index < 2 {
+                        HomeBigPostListCell()
+                    } else {
+                        HomePostListCell(index: index)
+                    }
                 }
             }
             
-            LazyVStack(spacing: 0) {
-                ForEach(Array(viewModel.categoryPopularPostItems[2..<7].enumerated()), id: \.offset) { index, item in
-                    HomePostListCell(index: index)
-                }
-            }
         } //VStack
         .background(Color.white)
     } //Body
     
-    @ViewBuilder func categoryButton(category: String, isSelected: Bool) -> some View {
+    @ViewBuilder func categoryButton(category: HomeTopic, isSelected: Bool) -> some View {
         Button(action: {
             viewModel.selectedCategory = category
+            Task {
+                await viewModel.getCategoryPopularPostItems()
+            }
         }) {
             HStack(spacing: 3) {
-                Image(systemName: viewModel.categoryIcons[category]!)
+                Image(systemName: viewModel.categoryIcons[category.id] ?? "")
                     .font(.system(size: 14))
-                Text(category)
+                Text(category.name)
                     .font(.system(size: 14, weight: isSelected ? .bold : .light))
             }
             .padding(.horizontal, 14)

--- a/Wastory/Wastory/View/HomeView/CategoryPopularPostView.swift
+++ b/Wastory/Wastory/View/HomeView/CategoryPopularPostView.swift
@@ -43,11 +43,17 @@ struct CategoryPopularPostView: View {
             .zIndex(1)
             
             LazyVStack(spacing: 0) {
-                ForEach(Array(viewModel.categoryPopularPostItems.prefix(2).enumerated()), id: \.offset) { index, item in
+                ForEach(Array(viewModel.categoryPopularPostItems.prefix(7).enumerated()), id: \.offset) { index, post in
                     if index < 2 {
-                        HomeBigPostListCell()
+                        HomeBigPostListCell(post: post)
                     } else {
-                        HomePostListCell(index: index)
+                        HomePostListCell(post: post)
+                    }
+                    
+                    if index == 6 || index == viewModel.categoryPopularPostItems.count - 1 {
+                        Divider()
+                            .foregroundStyle(Color.secondaryLabelColor)
+                            .padding(.horizontal, 20)
                     }
                 }
             }

--- a/Wastory/Wastory/View/HomeView/FocusPostListView.swift
+++ b/Wastory/Wastory/View/HomeView/FocusPostListView.swift
@@ -51,8 +51,9 @@ struct FocusPostListView: View {
                 .frame(height: 15)
             
             LazyVStack(spacing: 0) {
-                ForEach(Array(viewModel.focusPostList1Items.enumerated()), id: \.offset) { index, item in
-                    HomePostListCell(index: index)
+                ForEach(Array(viewModel.focusPostList1Items.enumerated()), id: \.offset) { index, post in
+                    HomePostListCell(post: Post.defaultPost)
+                    //TODO: Divier 추가
                 }
             }
         }
@@ -102,7 +103,8 @@ struct FocusPostListView: View {
             
             LazyVStack(spacing: 0) {
                 ForEach(Array(viewModel.focusPostList2Items.enumerated()), id: \.offset) { index, item in
-                    HomePostListCell(index: index)
+                    HomePostListCell(post: Post.defaultPost)
+                    //TODO: Divier 추가
                 }
             }
         }

--- a/Wastory/Wastory/View/HomeView/FocusPostListView.swift
+++ b/Wastory/Wastory/View/HomeView/FocusPostListView.swift
@@ -53,7 +53,7 @@ struct FocusPostListView: View {
             LazyVStack(spacing: 0) {
                 ForEach(Array(viewModel.focusPostList1Items.enumerated()), id: \.offset) { index, post in
                     HomePostListCell(post: Post.defaultPost)
-                    //TODO: Divier 추가
+                    //TODO: Divider 추가
                 }
             }
         }
@@ -104,7 +104,7 @@ struct FocusPostListView: View {
             LazyVStack(spacing: 0) {
                 ForEach(Array(viewModel.focusPostList2Items.enumerated()), id: \.offset) { index, item in
                     HomePostListCell(post: Post.defaultPost)
-                    //TODO: Divier 추가
+                    //TODO: Divider 추가
                 }
             }
         }

--- a/Wastory/Wastory/View/HomeView/HomePostListCells/HomeBigPostListCell.swift
+++ b/Wastory/Wastory/View/HomeView/HomePostListCells/HomeBigPostListCell.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct HomeBigPostListCell: View {
+    let post: Post
     
     @Environment(\.contentViewModel) var contentViewModel
     
@@ -26,8 +27,7 @@ struct HomeBigPostListCell: View {
                         .frame(height: 200)
                         .overlay {
                             ZStack {
-                                Image(systemName: "questionmark.text.page.fill")
-                                    .resizable()
+                                KFImageWithDefault(imageURL: post.mainImageUrl)
                                     .scaledToFill()
                                 
                                 Color.sheetOuterBackgroundColor
@@ -39,16 +39,15 @@ struct HomeBigPostListCell: View {
                         .foregroundStyle(Color.unreadNotification)
                         .padding(.horizontal, 20)
                         .overlay(
-                            contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
+                            contentViewModel.navigateToPostViewButton(post.id, post.blogID)
                         )
                     
                     //블로그 정보 button
-                    contentViewModel.navigateToBlogViewButton(tempBlog().id) {
+                    contentViewModel.navigateToBlogViewButton(post.blogID) {
                         HStack(alignment: .center, spacing: 8) {
                             // 블로그 mainImage
                             ZStack {
-                                Image(systemName: "questionmark.text.page.fill")
-                                    .resizable()
+                                KFImageWithDefaultIcon(imageURL: post.blogMainImageURL)
                                     .scaledToFill()
                                     .clipShape(Circle())
                                 
@@ -58,7 +57,7 @@ struct HomeBigPostListCell: View {
                             .frame(width: 23, height: 23)
                             
                             // 블로그 이름 Text
-                            Text("블로그이름")
+                            Text(post.blogName ?? "")
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundStyle(Color.todaysWastoryTextColor)
                         }
@@ -72,14 +71,14 @@ struct HomeBigPostListCell: View {
                         .frame(height: 11)
                     
                     VStack(alignment: .leading, spacing: 0) {
-                        Text("제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목목제목제목제목제목제목제목제목")
+                        Text(post.title)
                             .font(.system(size: 17, weight: .medium))
                             .lineLimit(2)
                         
                         Spacer()
                             .frame(height: 9)
                         
-                        Text("내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용")
+                        Text(post.description ?? "")
                             .font(.system(size: 14, weight: .light))
                             .lineLimit(2)
                             .foregroundStyle(Color.secondaryLabelColor)
@@ -89,18 +88,18 @@ struct HomeBigPostListCell: View {
                         
                         HStack(alignment: .center, spacing: 3) {
                             Image(systemName: "heart")
-                            Text("50")
+                            Text("\(post.likeCount)")
                             
                             Spacer()
                                 .frame(width: 5)
                             
                             Image(systemName: "ellipsis.bubble")
-                            Text("5")
+                            Text("\(post.commentCount)")
                             
                             Spacer()
                                 .frame(width: 5)
                             
-                            Text("5분 전")
+                            Text(timeAgo(from: post.createdAt))
                             
                             Spacer()
                         }
@@ -116,13 +115,10 @@ struct HomeBigPostListCell: View {
                 }
                 .padding(.horizontal, 20)
                 .overlay(
-                    contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
+                    contentViewModel.navigateToPostViewButton(post.id, post.blogID)
                     )
             } // VStack
         
     }
 }
 
-#Preview {
-    HomeBigPostListCell()
-}

--- a/Wastory/Wastory/View/HomeView/HomePostListCells/HomeBigPostListCell.swift
+++ b/Wastory/Wastory/View/HomeView/HomePostListCells/HomeBigPostListCell.swift
@@ -39,11 +39,11 @@ struct HomeBigPostListCell: View {
                         .foregroundStyle(Color.unreadNotification)
                         .padding(.horizontal, 20)
                         .overlay(
-                            contentViewModel.navigateToPostViewButton(tempPost(), tempBlog())
+                            contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
                         )
                     
                     //블로그 정보 button
-                    contentViewModel.navigateToBlogViewButton(tempBlog()) {
+                    contentViewModel.navigateToBlogViewButton(tempBlog().id) {
                         HStack(alignment: .center, spacing: 8) {
                             // 블로그 mainImage
                             ZStack {
@@ -116,7 +116,7 @@ struct HomeBigPostListCell: View {
                 }
                 .padding(.horizontal, 20)
                 .overlay(
-                    contentViewModel.navigateToPostViewButton(tempPost(), tempBlog())
+                    contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
                     )
             } // VStack
         

--- a/Wastory/Wastory/View/HomeView/HomePostListCells/HomePostListCell.swift
+++ b/Wastory/Wastory/View/HomeView/HomePostListCells/HomePostListCell.swift
@@ -42,6 +42,7 @@ struct HomePostListCell: View {
                     
                     Spacer()
                         .frame(height: 9)
+                    Spacer()
                     
                     HStack(alignment: .center, spacing: 3) {
                         Image(systemName: "heart")

--- a/Wastory/Wastory/View/HomeView/HomePostListCells/HomePostListCell.swift
+++ b/Wastory/Wastory/View/HomeView/HomePostListCells/HomePostListCell.swift
@@ -18,7 +18,7 @@ struct HomePostListCell: View {
             Spacer()
                 .frame(height: 20)
             
-            contentViewModel.navigateToBlogViewButton(tempBlog()) {
+            contentViewModel.navigateToBlogViewButton(tempBlog().id) {
                 HStack(spacing: 8) {
                     Image(systemName: "questionmark.text.page.fill")
                         .resizable()
@@ -74,7 +74,7 @@ struct HomePostListCell: View {
                     .frame(width: 100, height: 70)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                     .overlay {
-                        contentViewModel.navigateToPostViewButton(tempPost(), tempBlog())
+                        contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
                     }
             }
             
@@ -88,7 +88,7 @@ struct HomePostListCell: View {
         }
         .padding(.horizontal, 20)
         .background {
-            contentViewModel.navigateToPostViewButton(tempPost(), tempBlog())
+            contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
         }
     }
 }

--- a/Wastory/Wastory/View/HomeView/HomePostListCells/HomePostListCell.swift
+++ b/Wastory/Wastory/View/HomeView/HomePostListCells/HomePostListCell.swift
@@ -8,25 +8,24 @@
 import SwiftUI
 
 struct HomePostListCell: View {
+    let post: Post
     
     @Environment(\.contentViewModel) var contentViewModel
     
-    let index: Int
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Spacer()
                 .frame(height: 20)
             
-            contentViewModel.navigateToBlogViewButton(tempBlog().id) {
+            contentViewModel.navigateToBlogViewButton(post.blogID) {
                 HStack(spacing: 8) {
-                    Image(systemName: "questionmark.text.page.fill")
-                        .resizable()
+                    KFImageWithDefaultIcon(imageURL: post.blogMainImageURL)
                         .scaledToFill()
                         .frame(width: 20, height: 20)
                         .clipShape(Circle())
                     
-                    Text("블로그 이름")
+                    Text(post.blogName ?? "")
                         .font(.system(size: 13, weight: .regular))
                         .foregroundStyle(Color.primaryLabelColor)
                 }
@@ -37,7 +36,7 @@ struct HomePostListCell: View {
             
             HStack(alignment: .top, spacing: 0) {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목")
+                    Text(post.title)
                         .font(.system(size: 17, weight: .medium))
                         .lineLimit(2)
                     
@@ -46,18 +45,18 @@ struct HomePostListCell: View {
                     
                     HStack(alignment: .center, spacing: 3) {
                         Image(systemName: "heart")
-                        Text("50")
+                        Text("\(post.likeCount)")
                         
                         Spacer()
                             .frame(width: 5)
                         
                         Image(systemName: "ellipsis.bubble")
-                        Text("5")
+                        Text("\(post.commentCount)")
                         
                         Spacer()
                             .frame(width: 5)
                         
-                        Text("5분 전")
+                        Text(timeAgo(from: post.createdAt))
                         
                         Spacer()
                     }
@@ -68,31 +67,22 @@ struct HomePostListCell: View {
                 
                 Spacer()
                 
-                Image(systemName: "questionmark.text.page.fill")
-                    .resizable()
+                KFImageWithoutDefault(imageURL: post.mainImageUrl)
                     .scaledToFill()
                     .frame(width: 100, height: 70)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                     .overlay {
-                        contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
+                        contentViewModel.navigateToPostViewButton(post.id, post.blogID)
                     }
             }
             
             Spacer()
                 .frame(height: 17)
             
-            if index != 4 {
-                Divider()
-                    .foregroundStyle(Color.secondaryLabelColor)
-            }
         }
         .padding(.horizontal, 20)
         .background {
-            contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
+            contentViewModel.navigateToPostViewButton(post.id, post.blogID)
         }
     }
-}
-
-#Preview {
-    HomePostListCell(index: 5)
 }

--- a/Wastory/Wastory/View/HomeView/HomeView.swift
+++ b/Wastory/Wastory/View/HomeView/HomeView.swift
@@ -99,6 +99,7 @@ struct HomeView: View {
             }
             Task {
                 await viewModel.getTodaysWastoryItems()
+                viewModel.setDisplayedTodaysWastoryItems()
             }
             Task {
                 await viewModel.getTodaysWastoryListItems()
@@ -113,6 +114,7 @@ struct HomeView: View {
             }
             Task {
                 await viewModel.getTodaysWastoryListItems()
+                viewModel.setDisplayedTodaysWastoryItems()
             }
         }
         

--- a/Wastory/Wastory/View/HomeView/HomeView.swift
+++ b/Wastory/Wastory/View/HomeView/HomeView.swift
@@ -91,6 +91,30 @@ struct HomeView: View {
                 .background(Color.backgourndSpaceColor)
             } //ScrollView
         } //VStack
+        // MARK: Network
+        .onAppear {
+            Task {
+                await viewModel.getHomeTopicList()
+                await viewModel.getCategoryPopularPostItems()
+            }
+            Task {
+                await viewModel.getTodaysWastoryItems()
+            }
+            Task {
+                await viewModel.getTodaysWastoryListItems()
+            }
+        }
+        .refreshable {
+            Task {
+                await viewModel.getCategoryPopularPostItems()
+            }
+            Task {
+                await viewModel.getTodaysWastoryItems()
+            }
+            Task {
+                await viewModel.getTodaysWastoryListItems()
+            }
+        }
         
     }
     

--- a/Wastory/Wastory/View/HomeView/TodaysWastoryList/TodayWastoryListView.swift
+++ b/Wastory/Wastory/View/HomeView/TodaysWastoryList/TodayWastoryListView.swift
@@ -12,8 +12,8 @@ struct TodaysWastoryListView: View {
     
     var body: some View {
         LazyVStack(spacing: 0) {
-            ForEach(Array(viewModel.todaysWastoryListItems.enumerated()), id: \.offset) { index, item in
-                TodaysWastoryListCell(index: index + 1)
+            ForEach(Array(viewModel.todaysWastoryListItems.enumerated()), id: \.offset) { index, post in
+                TodaysWastoryListCell(post: post, index: index + 1)
             }
         }
         .background(Color.white)

--- a/Wastory/Wastory/View/HomeView/TodaysWastoryList/TodaysWastoryListCell.swift
+++ b/Wastory/Wastory/View/HomeView/TodaysWastoryList/TodaysWastoryListCell.swift
@@ -26,7 +26,7 @@ struct TodaysWastoryListCell: View {
                     .font(.system(size: 15, weight: .light))
                     .foregroundStyle(Color.secondaryLabelColor)
                 
-                contentViewModel.navigateToBlogViewButton(tempBlog()) {
+                contentViewModel.navigateToBlogViewButton(tempBlog().id) {
                     Text("블로그 이름")
                         .font(.system(size: 11, weight: .light))
                         .foregroundStyle(Color.primaryLabelColor)
@@ -89,7 +89,7 @@ struct TodaysWastoryListCell: View {
         }// VStack
         .padding(.horizontal, 20)
         .background {
-            contentViewModel.navigateToPostViewButton(tempPost(), tempBlog())
+            contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
         }
     }
 }

--- a/Wastory/Wastory/View/HomeView/TodaysWastoryList/TodaysWastoryListCell.swift
+++ b/Wastory/Wastory/View/HomeView/TodaysWastoryList/TodaysWastoryListCell.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct TodaysWastoryListCell: View {
+    let post: Post
     let index: Int
     
     @Environment(\.contentViewModel) var contentViewModel
@@ -26,8 +27,8 @@ struct TodaysWastoryListCell: View {
                     .font(.system(size: 15, weight: .light))
                     .foregroundStyle(Color.secondaryLabelColor)
                 
-                contentViewModel.navigateToBlogViewButton(tempBlog().id) {
-                    Text("블로그 이름")
+                contentViewModel.navigateToBlogViewButton(post.blogID) {
+                    Text(post.blogName ?? "")
                         .font(.system(size: 11, weight: .light))
                         .foregroundStyle(Color.primaryLabelColor)
                         .padding(.top, 4)
@@ -41,27 +42,29 @@ struct TodaysWastoryListCell: View {
             
             HStack(alignment: .top, spacing: 0) {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목")
+                    Text(post.title)
                         .font(.system(size: 17, weight: .medium))
                         .lineLimit(2)
                     
                     Spacer()
                         .frame(height: 9)
                     
+                    Spacer()
+                    
                     HStack(alignment: .center, spacing: 3) {
                         Image(systemName: "heart")
-                        Text("50")
+                        Text("\(post.likeCount)")
                         
                         Spacer()
                             .frame(width: 5)
                         
                         Image(systemName: "ellipsis.bubble")
-                        Text("5")
+                        Text("\(post.commentCount)")
                         
                         Spacer()
                             .frame(width: 5)
                         
-                        Text("5분 전")
+                        Text(timeAgo(from: post.createdAt))
                         
                         Spacer()
                     }
@@ -72,8 +75,7 @@ struct TodaysWastoryListCell: View {
                 
                 Spacer()
                 
-                Image(systemName: "questionmark.text.page.fill")
-                    .resizable()
+                KFImageWithoutDefault(imageURL: post.mainImageUrl)
                     .scaledToFill()
                     .frame(width: 100, height: 70)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -89,11 +91,7 @@ struct TodaysWastoryListCell: View {
         }// VStack
         .padding(.horizontal, 20)
         .background {
-            contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
+            contentViewModel.navigateToPostViewButton(post.id, post.blogID)
         }
     }
-}
-
-#Preview {
-    TodaysWastoryListCell(index: 1)
 }

--- a/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabCell.swift
+++ b/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabCell.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct TodaysWastoryPageTabCell: View {
+    let post: Post
     
     @Environment(\.contentViewModel) var contentViewModel
     
@@ -16,8 +17,7 @@ struct TodaysWastoryPageTabCell: View {
         ZStack {
             //Background Image
             GeometryReader { geometry in
-                Image(systemName: "questionmark.text.page.fill")
-                    .resizable()
+                KFImageWithDefault(imageURL: post.mainImageUrl)
                     .scaledToFill()
                     .frame(width: geometry.size.width ,height: geometry.size.height)
                     .clipped()
@@ -59,7 +59,7 @@ struct TodaysWastoryPageTabCell: View {
                     }
                     .padding(.bottom, 5)
                     
-                    Text("제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목제목")
+                    Text(post.title)
                         .font(.system(size: 23, weight: .semibold))
                         .foregroundStyle(Color.todaysWastoryTextColor)
                         .lineLimit(3)
@@ -67,11 +67,10 @@ struct TodaysWastoryPageTabCell: View {
                     
                     // 블로그 정보
                     HStack {
-                        contentViewModel.navigateToBlogViewButton(tempBlog().id) {
+                        contentViewModel.navigateToBlogViewButton(post.blogID) {
                             HStack(spacing: 8) {
                                 ZStack {
-                                    Image(systemName: "questionmark.text.page.fill")
-                                        .resizable()
+                                    KFImageWithDefaultIcon(imageURL: post.blogMainImageURL)
                                         .scaledToFill()
                                         .clipShape(Circle())
                                     
@@ -81,7 +80,7 @@ struct TodaysWastoryPageTabCell: View {
                                 .frame(width: 23, height: 23)
                                 
                                 // 블로그 이름 Text
-                                Text("블로그이름")
+                                Text(post.blogName ?? "")
                                     .font(.system(size: 14, weight: .semibold))
                                     .foregroundStyle(Color.todaysWastoryTextColor)
                             }
@@ -94,7 +93,7 @@ struct TodaysWastoryPageTabCell: View {
                 .padding(.horizontal, 25)
             }//Vstack
             .background {
-                contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
+                contentViewModel.navigateToPostViewButton(post.id, post.blogID)
             }
         }//ZStack
         .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabCell.swift
+++ b/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabCell.swift
@@ -67,7 +67,7 @@ struct TodaysWastoryPageTabCell: View {
                     
                     // 블로그 정보
                     HStack {
-                        contentViewModel.navigateToBlogViewButton(tempBlog()) {
+                        contentViewModel.navigateToBlogViewButton(tempBlog().id) {
                             HStack(spacing: 8) {
                                 ZStack {
                                     Image(systemName: "questionmark.text.page.fill")
@@ -94,7 +94,7 @@ struct TodaysWastoryPageTabCell: View {
                 .padding(.horizontal, 25)
             }//Vstack
             .background {
-                contentViewModel.navigateToPostViewButton(tempPost(), tempBlog())
+                contentViewModel.navigateToPostViewButton(tempPost().id, tempBlog().id)
             }
         }//ZStack
         .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabView.swift
+++ b/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabView.swift
@@ -15,7 +15,7 @@ struct TodaysWastoryPageTabView: View {
         VStack(spacing: 0) {
             // MARK: 오늘의 와스토리
             TabView(selection: $viewModel.todaysWastoryIndex) {
-                ForEach(Array(viewModel.displayedTodaysWastoryItems.prefix(5).enumerated()), id: \.offset) { index, post in
+                ForEach(Array(viewModel.displayedTodaysWastoryItems.enumerated()), id: \.1.id) { index, post in
                     TodaysWastoryPageTabCell(post: post)
                         .tag(index)
                 }

--- a/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabView.swift
+++ b/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabView.swift
@@ -15,7 +15,7 @@ struct TodaysWastoryPageTabView: View {
         VStack(spacing: 0) {
             // MARK: 오늘의 와스토리
             TabView(selection: $viewModel.todaysWastoryIndex) {
-                ForEach(Array(viewModel.displayedTodaysWastoryItems.enumerated()), id: \.1.id) { index, post in
+                ForEach(Array(viewModel.displayedTodaysWastoryItems.enumerated()), id: \.offset) { index, post in
                     TodaysWastoryPageTabCell(post: post)
                         .tag(index)
                 }

--- a/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabView.swift
+++ b/Wastory/Wastory/View/HomeView/TodaysWastoryPageTab/TodaysWastoryPageTabView.swift
@@ -15,8 +15,8 @@ struct TodaysWastoryPageTabView: View {
         VStack(spacing: 0) {
             // MARK: 오늘의 와스토리
             TabView(selection: $viewModel.todaysWastoryIndex) {
-                ForEach(viewModel.displayedTodaysWastoryItems.indices, id: \.self) { index in
-                    TodaysWastoryPageTabCell()
+                ForEach(Array(viewModel.displayedTodaysWastoryItems.prefix(5).enumerated()), id: \.offset) { index, post in
+                    TodaysWastoryPageTabCell(post: post)
                         .tag(index)
                 }
             }

--- a/Wastory/Wastory/View/KFImageWithDefault.swift
+++ b/Wastory/Wastory/View/KFImageWithDefault.swift
@@ -1,0 +1,39 @@
+//
+//  KFImageWithDefault.swift
+//  Wastory
+//
+//  Created by 중워니 on 1/27/25.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct KFImageWithDefault: View {
+    var imageURL: String?
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if imageURL ?? "" == "" {
+                Image("defaultImage")
+                    .resizable()
+            } else {
+                KFImage(URL(string: imageURL!))
+                    .resizable()
+            }
+        }
+    }
+}
+
+struct KFImageWithoutDefault: View {
+    var imageURL: String?
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if imageURL ?? "" == "" {
+            } else {
+                KFImage(URL(string: imageURL!))
+                    .resizable()
+            }
+        }
+    }
+}

--- a/Wastory/Wastory/View/KFImages.swift
+++ b/Wastory/Wastory/View/KFImages.swift
@@ -1,5 +1,5 @@
 //
-//  KFImageWithDefault.swift
+//  KFImages.swift
 //  Wastory
 //
 //  Created by 중워니 on 1/27/25.

--- a/Wastory/Wastory/View/KFImages.swift
+++ b/Wastory/Wastory/View/KFImages.swift
@@ -24,6 +24,22 @@ struct KFImageWithDefault: View {
     }
 }
 
+struct KFImageWithDefaultIcon: View {
+    var imageURL: String?
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if imageURL ?? "" == "" {
+                Image("myW")
+                    .resizable()
+            } else {
+                KFImage(URL(string: imageURL!))
+                    .resizable()
+            }
+        }
+    }
+}
+
 struct KFImageWithoutDefault: View {
     var imageURL: String?
     

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -60,7 +60,7 @@ struct MainTabView: View {
                     
                     
                     //MyBlogView로 추후 연결
-                    MyBlogView()
+                    BlogView(blogID: UserInfoRepository.shared.getBlogID())
                         .tabItem {
                             Image(mainTabViewModel.selectedTab == TabType.myBlog ? "myW.edge" : "myW")
                         }

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -75,6 +75,18 @@ struct MainTabView: View {
                     }
                 }
                 
+                VStack() {
+                    Spacer()
+                    HStack() {
+                        Spacer()
+                        KFImageWithoutDefault(imageURL: UserInfoRepository.shared.getBlogMainImageURL())
+                            .frame(width: 29, height: 29)
+                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                            .padding(.bottom, 9.5)
+                            .offset(x: -UIScreen.main.bounds.width/10 + 14.25)
+                    }
+                }
+                
                 // MARK: BlogSheet
                 BlogSheet(mainTabViewModel: mainTabViewModel)
                 
@@ -105,27 +117,10 @@ struct mainTabToolBarTrailingButtons: View {
             Button {
                 mainTabViewModel.toggleIsBlogSheetPresent()
             } label: {
-                ZStack {
-                    Circle()
-                        .fill(Color.mainWBackgroundGray)
-                        .frame(width: 32, height: 32)
-                    VStack(spacing: 2) {
-                        HStack(spacing: 4) {
-                            MainWCircleUnit()
-                            MainWCircleUnit()
-                            MainWCircleUnit()
-                        }
-                        HStack(spacing: 4) {
-                            MainWCircleUnit()
-                            MainWCircleUnit()
-                            MainWCircleUnit()
-                        }
-                        HStack(spacing: 4) {
-                            MainWCircleUnit()
-                            MainWCircleUnit()
-                        }
-                    }
-                }
+                KFImageWithDefaultIcon(imageURL: UserInfoRepository.shared.getBlogMainImageURL())
+                    .scaledToFill()
+                    .frame(width: 32, height: 32)
+                    .clipShape(Circle())
             }
         }
         .frame(height: 44)

--- a/Wastory/Wastory/View/MainTabView.swift
+++ b/Wastory/Wastory/View/MainTabView.swift
@@ -60,7 +60,7 @@ struct MainTabView: View {
                     
                     
                     //MyBlogView로 추후 연결
-                    BlogView(blogID: UserInfoRepository.shared.getBlogID())
+                    BlogView(blogID: UserInfoRepository.shared.getBlogID(), isMainTab: true)
                         .tabItem {
                             Image(mainTabViewModel.selectedTab == TabType.myBlog ? "myW.edge" : "myW")
                         }

--- a/Wastory/Wastory/View/MyBlogView/MyBlogSettingsView/MyBlogSettingsView.swift
+++ b/Wastory/Wastory/View/MyBlogView/MyBlogSettingsView/MyBlogSettingsView.swift
@@ -45,19 +45,10 @@ struct MyBlogSettingsView: View {
                                 .clipShape(Circle())
                                 .frame(width: 120, height: 120)
                         } else {
-                            if viewModel.isBlogMainImageURLEmpty {
-                                Image("defaultImage")
-                                    .resizable()
-                                    .scaledToFill()
-                                    .clipShape(Circle())
-                                    .frame(width: 120, height: 120)
-                            } else {
-                                KFImage(URL(string: viewModel.blogMainImageURL!))
-                                    .resizable()
-                                    .scaledToFill()
-                                    .clipShape(Circle())
-                                    .frame(width: 120, height: 120)
-                            }
+                            KFImageWithDefault(imageURL: viewModel.blogMainImageURL)
+                                .scaledToFill()
+                                .clipShape(Circle())
+                                .frame(width: 120, height: 120)
                         }
                         
                         

--- a/Wastory/Wastory/View/MyBlogView/MyBlogView.swift
+++ b/Wastory/Wastory/View/MyBlogView/MyBlogView.swift
@@ -6,55 +6,55 @@
 //
 
 import SwiftUI
-
-struct MyBlogView: View {
-    @Bindable var mainTabViewModel: MainTabViewModel
-    @Environment(\.contentViewModel) var contentViewModel
-    
-    
-    var body: some View {
-        VStack(spacing: 0) {
-            BlogView(blogID: UserInfoRepository.shared.getBlogID())
-//                .toolbarVisibility(.hidden, for: .navigationBar)
-        }
-        .toolbar{
-            ToolbarItem(placement: .navigationBarTrailing) {
-                HStack(spacing: 20) {
-                    contentViewModel.navigateToSearchViewButton(blogID: UserInfoRepository.shared.getBlogID()) {
-                        Text(Image(systemName: "magnifyingglass"))
-                            .foregroundStyle(Color.black)
-                    }
-                    
-                    Button {
-                        mainTabViewModel.toggleIsBlogSheetPresent()
-                    } label: {
-                        ZStack {
-                            Circle()
-                                .fill(Color.mainWBackgroundGray)
-                                .frame(width: 32, height: 32)
-                            VStack(spacing: 2) {
-                                HStack(spacing: 4) {
-                                    MainWCircleUnit()
-                                    MainWCircleUnit()
-                                    MainWCircleUnit()
-                                }
-                                HStack(spacing: 4) {
-                                    MainWCircleUnit()
-                                    MainWCircleUnit()
-                                    MainWCircleUnit()
-                                }
-                                HStack(spacing: 4) {
-                                    MainWCircleUnit()
-                                    MainWCircleUnit()
-                                }
-                            }
-                        }
-                    }
-                    
-                }
-            }
-        }
-        .toolbarVisibility(.visible, for: .navigationBar)
-    }
-        
-}
+//
+//struct MyBlogView: View {
+//    @Bindable var mainTabViewModel: MainTabViewModel
+//    @Environment(\.contentViewModel) var contentViewModel
+//    
+//    
+//    var body: some View {
+//        VStack(spacing: 0) {
+//            BlogView(blogID: UserInfoRepository.shared.getBlogID())
+////                .toolbarVisibility(.hidden, for: .navigationBar)
+//        }
+//        .toolbar{
+//            ToolbarItem(placement: .navigationBarTrailing) {
+//                HStack(spacing: 20) {
+//                    contentViewModel.navigateToSearchViewButton(blogID: UserInfoRepository.shared.getBlogID()) {
+//                        Text(Image(systemName: "magnifyingglass"))
+//                            .foregroundStyle(Color.black)
+//                    }
+//                    
+//                    Button {
+//                        mainTabViewModel.toggleIsBlogSheetPresent()
+//                    } label: {
+//                        ZStack {
+//                            Circle()
+//                                .fill(Color.mainWBackgroundGray)
+//                                .frame(width: 32, height: 32)
+//                            VStack(spacing: 2) {
+//                                HStack(spacing: 4) {
+//                                    MainWCircleUnit()
+//                                    MainWCircleUnit()
+//                                    MainWCircleUnit()
+//                                }
+//                                HStack(spacing: 4) {
+//                                    MainWCircleUnit()
+//                                    MainWCircleUnit()
+//                                    MainWCircleUnit()
+//                                }
+//                                HStack(spacing: 4) {
+//                                    MainWCircleUnit()
+//                                    MainWCircleUnit()
+//                                }
+//                            }
+//                        }
+//                    }
+//                    
+//                }
+//            }
+//        }
+//        .toolbarVisibility(.visible, for: .navigationBar)
+//    }
+//        
+//}

--- a/Wastory/Wastory/View/MyBlogView/MyBlogView.swift
+++ b/Wastory/Wastory/View/MyBlogView/MyBlogView.swift
@@ -2,25 +2,59 @@
 //  MyBlogView.swift
 //  Wastory
 //
-//  Created by 중워니 on 1/17/25.
+//  Created by 중워니 on 1/27/25.
 //
 
 import SwiftUI
 
 struct MyBlogView: View {
+    @Bindable var mainTabViewModel: MainTabViewModel
+    @Environment(\.contentViewModel) var contentViewModel
+    
+    
     var body: some View {
-        VStack {
-            NavigationLink(destination: MyCategoryView()) {
-                Text("카테고리 관리")
-            }
-            
-            NavigationLink(destination: MyBlogSettingsView()) {
-                Text("블로그 설정")
+        VStack(spacing: 0) {
+            BlogView(blogID: UserInfoRepository.shared.getBlogID())
+//                .toolbarVisibility(.hidden, for: .navigationBar)
+        }
+        .toolbar{
+            ToolbarItem(placement: .navigationBarTrailing) {
+                HStack(spacing: 20) {
+                    contentViewModel.navigateToSearchViewButton(blogID: UserInfoRepository.shared.getBlogID()) {
+                        Text(Image(systemName: "magnifyingglass"))
+                            .foregroundStyle(Color.black)
+                    }
+                    
+                    Button {
+                        mainTabViewModel.toggleIsBlogSheetPresent()
+                    } label: {
+                        ZStack {
+                            Circle()
+                                .fill(Color.mainWBackgroundGray)
+                                .frame(width: 32, height: 32)
+                            VStack(spacing: 2) {
+                                HStack(spacing: 4) {
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                }
+                                HStack(spacing: 4) {
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                }
+                                HStack(spacing: 4) {
+                                    MainWCircleUnit()
+                                    MainWCircleUnit()
+                                }
+                            }
+                        }
+                    }
+                    
+                }
             }
         }
+        .toolbarVisibility(.visible, for: .navigationBar)
     }
-}
-
-#Preview {
-    MyBlogView()
+        
 }

--- a/Wastory/Wastory/View/MyBlogView/MyCategoryView/MyCategoryCell.swift
+++ b/Wastory/Wastory/View/MyBlogView/MyCategoryView/MyCategoryCell.swift
@@ -210,7 +210,7 @@ struct MyCategoryCell: View {
             Divider()
                 .foregroundStyle(Color.secondaryLabelColor)
             
-            ForEach(category.children) { child in
+            ForEach(category.children ?? []) { child in
                 MyCategoryCell(category: child, viewModel: viewModel)
             }
         }//V

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
@@ -124,6 +124,35 @@ import Observation
         }
     }
     
+    // - 블로그 내 카테고리 글 get하기
+    func getPostsInCategory() async {
+        if !isPageEnded {
+            if selectedCategory.id != -1 {
+                do {
+                    let response = try await NetworkRepository.shared.getArticlesInBlogInCategory(blogID: self.blog.id, categoryID: self.selectedCategory.id, page: self.page)
+                    
+                    //comments 저장
+                    if self.page == 1 {
+                        blogPosts = response
+                    } else {
+                        blogPosts.append(contentsOf: response)
+                    }
+                    
+                    //pagination
+                    if !response.isEmpty {
+                        self.page += 1
+                    } else {
+                        self.isPageEnded = true
+                    }
+                } catch {
+                    print("Error: \(error.localizedDescription)")
+                }
+            } else {
+                await getPostsInBlog()
+            }
+        }
+    }
+    
     // - 블로그 내 인기글List views 순으로 get하기
     func getPopularBlogPosts() async {
         do {
@@ -142,6 +171,7 @@ import Observation
             print("Error: \(error.localizedDescription)")
         }
     }
+    
 }
 
 

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
@@ -135,7 +135,7 @@ import Observation
                 do {
                     let response = try await NetworkRepository.shared.getArticlesInBlogInCategory(blogID: self.blog.id, categoryID: self.selectedCategory.id, page: self.page)
                     
-                    //comments 저장
+                    //posts 저장
                     if self.page == 1 {
                         blogPosts = response
                     } else {

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
@@ -13,6 +13,7 @@ import Observation
 @Observable final class BlogViewModel {
     var blog: Blog = Blog.defaultBlog
     
+    var isMyBlog: Bool = false
     
     
     private var isNavTitleHidden: Bool = true
@@ -92,6 +93,9 @@ import Observation
     
     
     func initBlog(_ blogID: Int) async {
+        if blogID == UserInfoRepository.shared.getBlogID() {
+            isMyBlog = true
+        }
         do {
             self.blog = try await NetworkRepository.shared.getBlogByID(blogID: blogID)
         } catch {

--- a/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/BlogViewModel/BlogViewModel.swift
@@ -11,11 +11,8 @@ import SwiftUI
 import Observation
 
 @Observable final class BlogViewModel {
-    var blog: Blog?
+    var blog: Blog = Blog.defaultBlog
     
-    func initBlog(_ blog: Blog) {
-        self.blog = blog
-    }
     
     
     private var isNavTitleHidden: Bool = true
@@ -93,11 +90,20 @@ import Observation
     
     var blogPosts: [Post] = []
     
+    
+    func initBlog(_ blogID: Int) async {
+        do {
+            self.blog = try await NetworkRepository.shared.getBlogByID(blogID: blogID)
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }
+    }
+    
     // - 블로그 내 글List get하기 (pagination 기능 있음)
     func getPostsInBlog() async {
         if !isPageEnded {
             do {
-                let response = try await NetworkRepository.shared.getArticlesInBlog(blogID: self.blog!.id, page: self.page)
+                let response = try await NetworkRepository.shared.getArticlesInBlog(blogID: self.blog.id, page: self.page)
                 
                 //comments 저장
                 if self.page == 1 {
@@ -121,7 +127,7 @@ import Observation
     // - 블로그 내 인기글List views 순으로 get하기
     func getPopularBlogPosts() async {
         do {
-            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blog!.id, sortBy: PopularPostSortedType.views.api)
+            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blog.id, sortBy: PopularPostSortedType.views.api)
         } catch {
             print("Error: \(error.localizedDescription)")
         }
@@ -131,7 +137,7 @@ import Observation
     func getCategories() async {
         do {
             categories = [Category.allCategory]
-            categories += try await NetworkRepository.shared.getCategoriesInBlog(blogID: blog!.id)
+            categories += try await NetworkRepository.shared.getCategoriesInBlog(blogID: blog.id)
         } catch {
             print("Error: \(error.localizedDescription)")
         }

--- a/Wastory/Wastory/ViewModel/ContentViewModel/CommentViewModel/CommentViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/CommentViewModel/CommentViewModel.swift
@@ -70,6 +70,10 @@ import Observation
         writingCommentText.isEmpty
     }
     
+    func resetWritingCommentText() {
+        writingCommentText = ""
+    }
+    
     func setTargetCommentID(to id: Int) {
         targetCommentID = id
         isTargetToComment = true

--- a/Wastory/Wastory/ViewModel/ContentViewModel/CommentViewModel/CommentViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/CommentViewModel/CommentViewModel.swift
@@ -47,6 +47,7 @@ import Observation
     func resetPage() {
         page = 1
         isPageEnded = false
+        comments = []
     }
     
     //Network

--- a/Wastory/Wastory/ViewModel/ContentViewModel/CommentViewModel/CommentViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/CommentViewModel/CommentViewModel.swift
@@ -59,7 +59,7 @@ import Observation
     var writingCommentText: String = ""
     var isWritingCommentSecret: Bool = false
     var isTextFieldFocused: Bool = false
-    var targetCommentID: Int?
+    var targetComment: Comment?
     var isTargetToComment: Bool = false
     
     func setPostID(_ id: Int) {
@@ -74,13 +74,13 @@ import Observation
         writingCommentText = ""
     }
     
-    func setTargetCommentID(to id: Int) {
-        targetCommentID = id
+    func setTargetCommentID(to comment: Comment) {
+        targetComment = comment
         isTargetToComment = true
     }
     
     func resetTargetCommentID() {
-        targetCommentID = nil
+        targetComment = nil
         isTargetToComment = false
     }
     
@@ -95,7 +95,7 @@ import Observation
                 _ = try await NetworkRepository.shared.postComment(
                     postID: self.postID ?? 0,
                     content: writingCommentText,
-                    parentID: targetCommentID ?? nil,
+                    parentID: targetComment?.id ?? nil,
                     isSecret: self.isWritingCommentSecret
                 )
             } catch {

--- a/Wastory/Wastory/ViewModel/ContentViewModel/ContentViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/ContentViewModel.swift
@@ -11,14 +11,14 @@ import Observation
 @Observable final class ContentViewModel {
     
     // Button 동작
-    func navigateToBlogViewButton(_ blog: Blog, _ buttonContent: @escaping () -> some View) -> some View { //TODO: 보여줄 Blog 정하기{
-        NavigationLink(destination: BlogView(blog: blog)) {
+    func navigateToBlogViewButton(_ blogID: Int, _ buttonContent: @escaping () -> some View) -> some View { //TODO: 보여줄 Blog 정하기{
+        NavigationLink(destination: BlogView(blogID: blogID)) {
             buttonContent()
         }
     }
     
-    func navigateToPostViewButton(_ post: Post, _ blog: Blog) -> some View { //TODO: 보여줄 Post 정하기
-        NavigationLink(destination: PostView(post: post, blog: blog)) {
+    func navigateToPostViewButton(_ postID: Int, _ blogID: Int) -> some View { //TODO: 보여줄 Post 정하기
+        NavigationLink(destination: PostView(postID: postID, blogID: blogID)) {
             Rectangle()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .foregroundStyle(Color.clear)

--- a/Wastory/Wastory/ViewModel/ContentViewModel/ContentViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/ContentViewModel.swift
@@ -11,8 +11,8 @@ import Observation
 @Observable final class ContentViewModel {
     
     // Button 동작
-    func navigateToBlogViewButton(_ blogID: Int, _ buttonContent: @escaping () -> some View) -> some View { //TODO: 보여줄 Blog 정하기{
-        NavigationLink(destination: BlogView(blogID: blogID)) {
+    func navigateToBlogViewButton(_ blogID: Int, _ categoryID: Int? = nil, _ buttonContent: @escaping () -> some View) -> some View { //TODO: 보여줄 Blog 정하기{
+        NavigationLink(destination: BlogView(blogID: blogID, categoryID: categoryID ?? -1)) {
             buttonContent()
         }
     }

--- a/Wastory/Wastory/ViewModel/ContentViewModel/ContentViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/ContentViewModel.swift
@@ -31,12 +31,7 @@ import Observation
         }
     }
     
-    
-    //network
-    func getBlogByID(_ blogID: Int) async throws -> Blog {
-        let response = try await NetworkRepository.shared.getBlogByID(blogID: blogID)
-        return response
-    }
+
 }
 
 

--- a/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
@@ -11,8 +11,8 @@ import SwiftUI
 import Observation
 
 @Observable final class PostViewModel {
-    var post: Post?
-    var blog: Blog?
+    var post: Post = Post.defaultPost
+    var blog: Blog = Blog.defaultBlog
     
     
     
@@ -80,7 +80,7 @@ import Observation
     
     func deleteSelfPost(at List: inout [Post]) {
         for (index, item) in List.enumerated() {
-            if item == self.post! {
+            if item == self.post {
                 List.remove(at: index)
             }
         }
@@ -90,7 +90,7 @@ import Observation
         // - 블로그 내 인기글List views 순으로 get하기
     func getPopularBlogPosts() async {
         do {
-            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blog!.id, sortBy: PopularPostSortedType.views.api)
+            popularBlogPosts = try await NetworkRepository.shared.getTopArticlesInBlog(blogID: self.blog.id, sortBy: PopularPostSortedType.views.api)
             deleteSelfPost(at: &popularBlogPosts)
         } catch {
             print("Error: \(error.localizedDescription)")
@@ -99,16 +99,16 @@ import Observation
     
         // - 블로그 내 같은 카테고리글List get
     func getPostsInBlogInCategory() async {
-        if post!.categoryID == nil {
+        if post.categoryID == nil {
             do {
-            categoryBlogPosts = try await NetworkRepository.shared.getArticlesInBlog(blogID: blog!.id, page: 1)
+            categoryBlogPosts = try await NetworkRepository.shared.getArticlesInBlog(blogID: blog.id, page: 1)
             deleteSelfPost(at: &categoryBlogPosts)
             } catch {
                 print("Error: \(error.localizedDescription)")
             }
         } else {
             do {
-                categoryBlogPosts = try await NetworkRepository.shared.getArticlesInBlogInCategory(blogID: blog!.id, categoryID: post!.categoryID!, page: 1)
+                categoryBlogPosts = try await NetworkRepository.shared.getArticlesInBlogInCategory(blogID: blog.id, categoryID: post.categoryID!, page: 1)
                 deleteSelfPost(at: &categoryBlogPosts)
             } catch {
                 print("Error: \(error.localizedDescription)")
@@ -119,7 +119,7 @@ import Observation
         // - 유저가 해당 글을 좋아요 했는지 저장
     func getIsLiked() async {
         do {
-            let response = try await NetworkRepository.shared.getIsLiked(postID: post!.id)
+            let response = try await NetworkRepository.shared.getIsLiked(postID: post.id)
             isLiked = response
         } catch {
             print("Error: \(error.localizedDescription)")
@@ -130,9 +130,9 @@ import Observation
         // - 좋아요 기능
     func createLike() async {
         do {
-            try await NetworkRepository.shared.postLike(postID: post!.id)
+            try await NetworkRepository.shared.postLike(postID: post.id)
             isLiked = true
-            post!.likeCount += 1
+            post.likeCount += 1
         } catch {
             print("Error: \(error.localizedDescription)")
         }
@@ -141,9 +141,9 @@ import Observation
         // - 좋아요 취소 기능
     func deleteLike() async {
         do {
-            try await NetworkRepository.shared.deleteLike(postID: post!.id)
+            try await NetworkRepository.shared.deleteLike(postID: post.id)
             isLiked = false
-            post!.likeCount -= 1
+            post.likeCount -= 1
         } catch {
             print("Error: \(error.localizedDescription)")
         }

--- a/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
@@ -65,13 +65,14 @@ import Observation
     
     var isLiked: Bool = false
     
-    var categoryName: String = "카테고리 get이 필요합니다"
+    var categoryName: String = ""
     
     
     func initContent(_ postID: Int, _ blogID: Int) async {
         do {
             self.post = try await NetworkRepository.shared.getArticle(postID: postID)
             self.blog = try await NetworkRepository.shared.getBlogByID(blogID: blogID)
+            //self.categoryName = try await NetworkRepository.shared.getCategory(categoryID: post.categoryID!).categoryName
         } catch {
             print("Error: \(error.localizedDescription)")
             

--- a/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
@@ -72,7 +72,7 @@ import Observation
         do {
             self.post = try await NetworkRepository.shared.getArticle(postID: postID)
             self.blog = try await NetworkRepository.shared.getBlogByID(blogID: blogID)
-            //self.categoryName = try await NetworkRepository.shared.getCategory(categoryID: post.categoryID!).categoryName
+            self.categoryName = try await NetworkRepository.shared.getCategory(categoryID: post.categoryID!).categoryName
         } catch {
             print("Error: \(error.localizedDescription)")
             

--- a/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
@@ -65,6 +65,8 @@ import Observation
     
     var isLiked: Bool = false
     
+    var categoryName: String = "카테고리 get이 필요합니다"
+    
     
     func initContent(_ postID: Int, _ blogID: Int) async {
         do {

--- a/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
@@ -14,10 +14,6 @@ import Observation
     var post: Post?
     var blog: Blog?
     
-    func initContent(_ post: Post, _ blog: Blog) {
-        self.post = post
-        self.blog = blog
-    }
     
     
     
@@ -68,6 +64,19 @@ import Observation
     var categoryBlogPosts: [Post] = []
     
     var isLiked: Bool = false
+    
+    
+    func initContent(_ postID: Int, _ blogID: Int) async {
+        do {
+            self.post = try await NetworkRepository.shared.getArticle(postID: postID)
+            self.blog = try await NetworkRepository.shared.getBlogByID(blogID: blogID)
+        } catch {
+            print("Error: \(error.localizedDescription)")
+            
+        }
+    }
+    
+    
     
     func deleteSelfPost(at List: inout [Post]) {
         for (index, item) in List.enumerated() {

--- a/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
@@ -82,8 +82,9 @@ import Observation
     
     func deleteSelfPost(at List: inout [Post]) {
         for (index, item) in List.enumerated() {
-            if item == self.post {
+            if item.id == self.post.id {
                 List.remove(at: index)
+                break
             }
         }
     }

--- a/Wastory/Wastory/ViewModel/FeedViewModel/FeedViewModel.swift
+++ b/Wastory/Wastory/ViewModel/FeedViewModel/FeedViewModel.swift
@@ -63,9 +63,40 @@ import Observation
         isScrolled
     }
     
+    //pagination
+    var page = 1
+    var isPageEnded: Bool = false
+    
+    func resetPage() {
+        page = 1
+        isPageEnded = false
+        posts = []
+    }
+    
     //Network
     var posts: [Post] = []
     
+    
+    func getPosts() async {
+        do {
+            let response = try await NetworkRepository.shared.getArticlesOfSubscription(blogID: UserInfoRepository.shared.getBlogID(), page: self.page)
+            
+            if self.page == 1 {
+                self.posts = response
+            } else {
+                self.posts.append(contentsOf: response)
+            }
+            
+            //pagination
+            if !response.isEmpty {
+                self.page += 1
+            } else {
+                self.isPageEnded = true
+            }
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }
+    }
 }
 
 

--- a/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
+++ b/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
@@ -44,37 +44,10 @@ import Observation
     }
     
     
-    //TodaysWastoryPageTab
-    var todaysWastoryItems = ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5"]
-    var displayedTodaysWastoryItems: [String] = []
-    var todaysWastoryIndex: Int = 1
-
-    //TodaysWastoryList
-    var todaysWastoryListItems = ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5"]
-    
-    //Category Popular Post List
-    let categoryList = ["여행·맛집", "리빙·스타일", "가족·연애", "직장·자기계발", "시사·지식", "도서·창작", "엔터테인먼트", "취미·건강"]
-    
-    let categoryIcons : [String: String] =
-    ["여행·맛집": "airplane.departure", "리빙·스타일": "sofa", "가족·연애": "person.2", "직장·자기계발": "cpu", "시사·지식": "chart.bar.xaxis", "도서·창작": "book", "엔터테인먼트": "tv", "취미·건강": "figure.indoor.soccer"]
-    
-    var selectedCategory: String = "여행·맛집"
-    
-    var categoryPopularPostItems: [String] = ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7"]
-    
-    
-    //Focus Post List
-    var focusPostList1Items: [String] = ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5"]
-    
-    var focusPostList2Items: [String] = ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5"]
-    
-    init() {
-        setDisplayedTodaysWastoryItems()
-    }
-    
     //TodayWastoryPageTab
     func setDisplayedTodaysWastoryItems() {
         displayedTodaysWastoryItems = [todaysWastoryItems.last!] + todaysWastoryItems + [todaysWastoryItems.first!]
+        print(displayedTodaysWastoryItems)
     }
     
     func setNextTodaysWastoryIndex(with newIndex: Int) {
@@ -110,5 +83,65 @@ import Observation
         }
     }
     
+    //Network
+    //TodaysWastoryPageTab
+    var todaysWastoryItems: [Post] = []
+    var displayedTodaysWastoryItems: [Post] = []
+    var todaysWastoryIndex: Int = 1
+
+    //TodaysWastoryList
+    var todaysWastoryListItems: [Post] = []
     
+    //Category Popular Post List
+    var categoryList: [HomeTopic] = []
+    
+    let categoryIcons : [Int: String] =
+    [1: "airplane.departure", 2: "sofa", 3: "person.2", 4: "cpu", 5: "chart.bar.xaxis", 6: "book", 7: "tv", 8: "figure.indoor.soccer"]
+    
+    var selectedCategory: HomeTopic = HomeTopic.defaultHomeTopic
+    
+    var categoryPopularPostItems: [Post] = []
+    
+    
+    //Focus Post List
+    var focusPostList1Items: [String] = ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5"]
+    
+    var focusPostList2Items: [String] = ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5"]
+    
+    
+    func getTodaysWastoryItems() async {
+        do {
+            todaysWastoryItems = try await NetworkRepository.shared.getArticlesTodayWastory()
+            setDisplayedTodaysWastoryItems()
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }
+    }
+    
+    func getTodaysWastoryListItems() async {
+        do {
+            todaysWastoryListItems = try await NetworkRepository.shared.getArticlesWeeklyWastory()
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }
+    }
+    
+    func getHomeTopicList() async {
+        do {
+            categoryList = Array(try await NetworkRepository.shared.getHomeTopicList()[1...9])
+            selectedCategory = categoryList.first!
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }
+    }
+    
+    func getCategoryPopularPostItems() async {
+        do {
+            categoryPopularPostItems = try await NetworkRepository.shared.getArticlesHomeTopic(highHomeTopicID: selectedCategory.id)
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }
+    }
+    
+    //TODO: Focus get
 }

--- a/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
+++ b/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
@@ -96,7 +96,7 @@ import Observation
     var categoryList: [HomeTopic] = []
     
     let categoryIcons : [Int: String] =
-    [1: "airplane.departure", 2: "sofa", 3: "person.2", 4: "cpu", 5: "chart.bar.xaxis", 6: "book", 7: "tv", 8: "figure.indoor.soccer"]
+    [2: "airplane.departure", 3: "sofa", 4: "person.2", 5: "cpu", 6: "chart.bar.xaxis", 7: "book", 8: "tv", 9: "figure.indoor.soccer"]
     
     var selectedCategory: HomeTopic = HomeTopic.defaultHomeTopic
     
@@ -128,7 +128,7 @@ import Observation
     
     func getHomeTopicList() async {
         do {
-            categoryList = Array(try await NetworkRepository.shared.getHomeTopicList()[1...9])
+            categoryList = Array(try await NetworkRepository.shared.getHomeTopicList()[1...8])
             selectedCategory = categoryList.first!
         } catch {
             print("Error: \(error.localizedDescription)")

--- a/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
+++ b/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
@@ -47,7 +47,6 @@ import Observation
     //TodayWastoryPageTab
     func setDisplayedTodaysWastoryItems() {
         displayedTodaysWastoryItems = [todaysWastoryItems.last!] + todaysWastoryItems + [todaysWastoryItems.first!]
-        print(displayedTodaysWastoryItems)
     }
     
     func setNextTodaysWastoryIndex(with newIndex: Int) {

--- a/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
+++ b/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import Observation
 
+@MainActor
 @Observable final class HomeViewModel {
     //NavBar Controller
     private var isScrolled: Bool = false
@@ -47,18 +48,21 @@ import Observation
     //TodayWastoryPageTab
     func setDisplayedTodaysWastoryItems() {
         displayedTodaysWastoryItems = [todaysWastoryItems.last!] + todaysWastoryItems + [todaysWastoryItems.first!]
+        print(displayedTodaysWastoryItems)
     }
     
     func setNextTodaysWastoryIndex(with newIndex: Int) {
         if newIndex == 0 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
                 self.todaysWastoryIndex = self.todaysWastoryItems.count // 마지막 실제 데이터로 이동
+                print(self.todaysWastoryIndex)
             }
         }
         // 마지막에서 첫 번째로 이동해야 할 때
         else if newIndex == todaysWastoryItems.count + 1 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
                 self.todaysWastoryIndex = 1 // 첫 번째 실제 데이터로 이동
+                print(self.todaysWastoryIndex)
             }
         }
     }
@@ -111,7 +115,6 @@ import Observation
     func getTodaysWastoryItems() async {
         do {
             todaysWastoryItems = try await NetworkRepository.shared.getArticlesTodayWastory()
-            setDisplayedTodaysWastoryItems()
         } catch {
             print("Error: \(error.localizedDescription)")
         }

--- a/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
+++ b/Wastory/Wastory/ViewModel/HomeViewModel/HomeViewModel.swift
@@ -55,14 +55,12 @@ import Observation
         if newIndex == 0 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
                 self.todaysWastoryIndex = self.todaysWastoryItems.count // 마지막 실제 데이터로 이동
-                print(self.todaysWastoryIndex)
             }
         }
         // 마지막에서 첫 번째로 이동해야 할 때
         else if newIndex == todaysWastoryItems.count + 1 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
                 self.todaysWastoryIndex = 1 // 첫 번째 실제 데이터로 이동
-                print(self.todaysWastoryIndex)
             }
         }
     }

--- a/Wastory/Wastory/ViewModel/MyBlogViewModel/MyBlogSettingsViewModel.swift
+++ b/Wastory/Wastory/ViewModel/MyBlogViewModel/MyBlogSettingsViewModel.swift
@@ -39,7 +39,7 @@ import Observation
     }
     
     var isBlogMainImageURLEmpty: Bool {
-        blogMainImageURL == nil
+        blogMainImageURL == "" || blogMainImageURL == nil
     }
     
     func getInitialData() async {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[O] 기능 추가
 -[] 기능 삭제
 -[O] 버그 수정
 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Feature/post blog view restruct  -> main

### 변경 사항

#### 버그 수정
- commentView에서 답글의 답글을 달 수 있도록 수정
- Blog Setting View 에서 KFImage 가 없는 경우 default image로 되도록함
- BlogCategorySheet에서 child category의 article count가 제대로 적용되지 않던 점 수정
- PostViewModel의 deleteSelfPost func에서 post를 id를 기준으로 비교해 제대로 삭제할 수 있도록 수정

#### 추가
- 블로그, 포스트 뷰를 ID로 불러오게 함(기존에는 Blog, Post Model자체를 이용함)
- PostCell에서 Blog를 get하지 않고 api에서 미리 주도록 변경된 것을 적용
- KFImages 에서 KFImageWithDefault (url이 없으면 defaultImage표시) / KFImageWithDefaultIcon (url이 없으면 myW 표시) // KFImageWithoutDefault (url이 없으면 표시하지 않음) 추가
- myBlogView를 삭제하고 blogView(자기블로그)로 바꿈. isMyBlog를 이용해 blogView를 변환함
- HomeTab Networking 구현
- mainTabView 우측 아래 myBlogTab Item위에 ZStack으로 BlogMainImage 표시
- category에 속한 글을 PostView에서 ‘더보기’ 또는 ‘카테고리 이름’버튼으로 navigate 했을 때 push 된 BlogView에서 카테고리 선택이 잘 적용되도록 변경
- CommentView pagination 

### 추후 보완 사항
- Focus Posts 필요
- blog우측상단 위 버튼 sheet presentation 할 수 있도록 해야함
- comment 수정(추후), 비밀comment

- 구독관련 추가 필요!
- myBlog를 mainTab에서 열었을때 navbar가 없는 문제 <- 그냥 없이 가도 괜찮을 것 같긴합니다.
- searchView 네트워킹 연결 필요
- Notification 연결 필요



https://github.com/user-attachments/assets/878e0dbc-3e9e-4a89-aad1-feb79d16c077

<img width="348" alt="스크린샷 2025-01-27 18 07 45" src="https://github.com/user-attachments/assets/496cf4f2-dfca-4456-aac3-b0666c3264f2" />
