### PR TITLE
Feat: Store draft & Article with Image

### DIFF
--- a/Wastory/Wastory/Model/Draft.swift
+++ b/Wastory/Wastory/Model/Draft.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Draft: Codable, Identifiable {
+struct Draft: Codable {
     let id: Int             // Draft ID (주소)
     let title: String       // Draft 제목
     let content: String     // Draft 내용 (HTML을 String으로 변환하여 저장)
@@ -21,11 +21,23 @@ struct Draft: Codable, Identifiable {
     }
 }
 
+struct DraftDto: Codable, Identifiable, Hashable {
+    let id: Int             // Draft ID (주소)
+    let title: String       // Draft 제목
+    let createdAt: Date     // 저장된 시간
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case createdAt = "created_at"
+    }
+}
+
 struct DraftListDto: Codable {
     let page: Int
     let perPage: Int
     let totalCount: Int
-    let drafts: [Draft]
+    let drafts: [DraftDto]
     
     private enum CodingKeys: String, CodingKey {
         case page

--- a/Wastory/Wastory/Model/Draft.swift
+++ b/Wastory/Wastory/Model/Draft.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Draft: Codable {
     let id: Int             // Draft ID (주소)
     let title: String       // Draft 제목
-    let content: String     // Draft 내용 (HTML을 String으로 변환하여 저장)
+    let content: String     // Draft 내용 (SwiftData를 String으로 변환하여 저장)
     let createdAt: Date     // 저장된 시간
     
     private enum CodingKeys: String, CodingKey {

--- a/Wastory/Wastory/PhotoViewController/CameraPicker.swift
+++ b/Wastory/Wastory/PhotoViewController/CameraPicker.swift
@@ -1,0 +1,48 @@
+//
+//  CameraPicker.swift
+//  Wastory
+//
+//  Created by mujigae on 1/29/25.
+//
+
+import SwiftUI
+
+struct CameraPicker: UIViewControllerRepresentable {
+    @Binding var selectedImage: UIImage?
+    @Environment(\.presentationMode) var presentationMode
+    var sourceType: UIImagePickerController.SourceType
+    
+    func makeUIViewController(context: UIViewControllerRepresentableContext<CameraPicker>) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.delegate = context.coordinator
+        picker.sourceType = sourceType
+        picker.mediaTypes = ["public.image"]
+        //picker.modalPresentationStyle = .fullScreen
+        return picker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: CameraPicker
+        
+        init(_ parent: CameraPicker) {
+            self.parent = parent
+        }
+       
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                parent.selectedImage = image
+            }
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+        
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+    }
+}

--- a/Wastory/Wastory/Repository/NetworkRepository.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository.swift
@@ -295,16 +295,14 @@ final class NetworkRepository {
         )
         urlRequest.httpBody = try JSONEncoder().encode(requestBody)
         
-        logRequest(urlRequest, body: requestBody)
+        logRequest(urlRequest)
         
-        let response = try await AF.request(
+        _ = try await AF.request(
             urlRequest,
             interceptor: NetworkInterceptor()
         ).validate()
         .serializingData()
         .value
-        
-        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
     }
     
     func getArticlesInBlog(blogID: Int, page: Int) async throws -> [Post] {
@@ -393,7 +391,7 @@ final class NetworkRepository {
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
         
-        let response = try await AF.request(
+        _ = try await AF.request(
             urlRequest,
             interceptor: NetworkInterceptor()
         ).validate()

--- a/Wastory/Wastory/Repository/NetworkRepository.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository.swift
@@ -357,7 +357,7 @@ final class NetworkRepository {
         )
         urlRequest.httpBody = try JSONEncoder().encode(requestBody)
         
-        logRequest(urlRequest, body: requestBody)
+        logRequest(urlRequest)
         
         let decoder = JSONDecoder()
         let dateFormatter = DateFormatter()
@@ -370,8 +370,6 @@ final class NetworkRepository {
         ).validate()
         .serializingDecodable(Draft.self, decoder: decoder)
         .value
-            
-        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
         
         return response
     }
@@ -388,7 +386,7 @@ final class NetworkRepository {
         )
         urlRequest.httpBody = try JSONEncoder().encode(requestBody)
         
-        logRequest(urlRequest, body: requestBody)
+        logRequest(urlRequest)
         
         let decoder = JSONDecoder()
         let dateFormatter = DateFormatter()
@@ -401,8 +399,6 @@ final class NetworkRepository {
         ).validate()
         .serializingDecodable(Draft.self, decoder: decoder)
         .value
-            
-        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
     }
     
     func getDraft(draftID: Int) async throws -> Draft {
@@ -425,8 +421,6 @@ final class NetworkRepository {
         ).validate()
         .serializingDecodable(Draft.self, decoder: decoder)
         .value
-            
-        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
         
         return response
     }
@@ -451,8 +445,6 @@ final class NetworkRepository {
         ).validate()
         .serializingDecodable(DraftListDto.self, decoder: decoder)
         .value
-            
-        logResponse(response, url: urlRequest.url?.absoluteString ?? "unknown")
         
         return response
     }

--- a/Wastory/Wastory/Repository/NetworkRepository.swift
+++ b/Wastory/Wastory/Repository/NetworkRepository.swift
@@ -433,9 +433,9 @@ final class NetworkRepository {
     
     func getDraftsInBlog(blogID: Int, page: Int) async throws -> DraftListDto {
         let urlRequest = try URLRequest(
-            url: NetworkRouter.getDraftsInBlog(blogID: blogID).url,
-            method: NetworkRouter.getDraftsInBlog(blogID: blogID).method,
-            headers: NetworkRouter.getDraftsInBlog(blogID: blogID).headers
+            url: NetworkRouter.getDraftsInBlog(blogID: blogID, page: page).url,
+            method: NetworkRouter.getDraftsInBlog(blogID: blogID, page: page).method,
+            headers: NetworkRouter.getDraftsInBlog(blogID: blogID, page: page).headers
         )
         
         logRequest(urlRequest)
@@ -446,10 +446,7 @@ final class NetworkRepository {
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
         
         let response = try await AF.request(
-            urlRequest as! URLConvertible,
-            parameters: [
-                "page": page
-            ],
+            urlRequest,
             interceptor: NetworkInterceptor()
         ).validate()
         .serializingDecodable(DraftListDto.self, decoder: decoder)

--- a/Wastory/Wastory/Repository/NetworkRouter.swift
+++ b/Wastory/Wastory/Repository/NetworkRouter.swift
@@ -78,7 +78,7 @@ enum NetworkRouter {
     case postDraft
     case patchDraft(draftID: Int)
     case getDraft(draftID: Int)
-    case getDraftsInBlog(blogID: Int)
+    case getDraftsInBlog(blogID: Int, page: Int)
     case deleteDraft(draftID: Int)
     
     var url: URL {
@@ -156,7 +156,7 @@ enum NetworkRouter {
         case .postDraft: "/drafts/create"
         case let .patchDraft(draftID): "/drafts/update/\(draftID)"
         case let .getDraft(draftID): "/drafts/get/\(draftID)"
-        case let .getDraftsInBlog(blogID): "/drafts/blogs/\(blogID)"
+        case let .getDraftsInBlog(blogID, page): "/drafts/blogs/\(blogID)/\(page)"
         case let .deleteDraft(draftID): "/drafts/delete/\(draftID)"
         }
     }

--- a/Wastory/Wastory/View/ArticleView/ArticleDraftSheet.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleDraftSheet.swift
@@ -1,0 +1,102 @@
+//
+//  ArticleDraftSheet.swift
+//  Wastory
+//
+//  Created by mujigae on 1/28/25.
+//
+
+import SwiftUI
+
+struct ArticleDraftSheet: View {
+    @Bindable var viewModel: ArticleViewModel
+    
+    var body: some View {
+        ZStack {
+            // MARK: Background Dimming
+            (viewModel.isDraftSheetPresent ? Color.sheetOuterBackgroundColor : Color.clear)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    viewModel.toggleIsDraftSheetPresent()
+                }
+
+            VStack {
+                Spacer()
+                if viewModel.isDraftSheetPresent {
+                    let sheetHeight: CGFloat = UIScreen.main.bounds.height * 0.8
+                    
+                    ZStack {
+                        VStack(alignment: .leading, spacing: 0) {
+                            Spacer()
+                                .frame(height: 30)
+                            HStack(alignment: .top, spacing: 5) {
+                                Text("임시저장")
+                                    .font(.system(size: 28, weight: .regular))
+                                    .foregroundStyle(Color.primaryLabelColor)
+                                Text(String(viewModel.getDraftsCount()))
+                                    .font(.system(size: 12, weight: .regular))
+                                    .foregroundStyle(.gray)
+                                Spacer()
+                            }
+                            .padding(.horizontal, 20)
+                            .padding(.bottom, 16)
+                            Spacer()
+                                .frame(height: 10)
+                            ScrollView {
+                                VStack(spacing: 0) {
+                                    ForEach(Array(viewModel.drafts.enumerated()), id: \.offset) { index, draft in
+                                        DraftButton(draft: draft)
+                                            .onAppear {
+                                                if index == viewModel.drafts.count - 1 {
+                                                    Task {
+                                                        await viewModel.getDrafts()
+                                                    }
+                                                }
+                                            }
+                                    }
+                                }
+                                Spacer()
+                                    .frame(height: 30)
+                            }
+                        }
+                        .frame(height: sheetHeight)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.white)
+                        .cornerRadius(20)
+                    }
+                    .background(Color.clear)
+                    .transition(.move(edge: .bottom))
+                    .animation(.easeInOut, value: viewModel.isDraftSheetPresent)
+                }
+            }
+        }
+        .ignoresSafeArea()
+    }
+    
+    // MARK: DraftSheet Row
+    @ViewBuilder func DraftButton(draft: DraftDto) -> some View {
+        Button {
+            Task {
+                await viewModel.getDraft(draftID: draft.id)
+                viewModel.toggleIsDraftSheetPresent()
+            }
+        } label: {
+            VStack(spacing: 5) {
+                HStack {
+                    Text(draft.title.isEmpty ? "제목 없음" : draft.title)
+                        .font(.system(size: 14, weight: .light))
+                        .foregroundStyle(.black)
+                    Spacer()
+                }
+                HStack {
+                    Text(timeAgo(from: draft.createdAt))
+                        .font(.system(size: 12, weight: .light))
+                        .foregroundStyle(Color.emailCautionTextGray)
+                    Spacer()
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 20)
+        SettingDivider(thickness: 1)
+    }
+}

--- a/Wastory/Wastory/View/ArticleView/ArticleSettingView.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleSettingView.swift
@@ -178,6 +178,7 @@ struct ArticleSettingView: View {
                         Text(viewModel.homeTopic.id == 0 ? "선택 안 함" : viewModel.homeTopic.name)
                             .font(.system(size: 14, weight: .ultraLight))
                             .foregroundStyle(Color.black)
+                            .lineLimit(1)
                         Spacer()
                             .frame(width: 10)
                         Image(systemName: "chevron.right")

--- a/Wastory/Wastory/View/ArticleView/ArticleSettingView.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleSettingView.swift
@@ -64,8 +64,8 @@ struct ArticleSettingView: View {
                         if let mainImage = viewModel.mainImage {
                             Image(uiImage: mainImage)
                                 .resizable()
-                                .frame(width: 100, height: 100)
                                 .scaledToFill()
+                                .frame(width: 100, height: 100)
                                 .clipped()
                         }
                         else {

--- a/Wastory/Wastory/View/ArticleView/ArticleView.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleView.swift
@@ -73,9 +73,9 @@ struct ArticleView: View {
                             .frame(width: 1, height: 10)
                             .foregroundStyle(Color.codeRequestButtonGray)
                         Button {
-                            // 임시 저장한 글들을 불러 오는 기능
                             isTitleFocused = false
                             isTextFocused = false
+                            viewModel.isDraftSheetPresent = true
                         } label: {
                             Text(viewModel.getDraftsCount())
                                 .font(.system(size: 14, weight: .regular))
@@ -199,8 +199,13 @@ struct ArticleView: View {
                     )
                     .transition(.opacity)
             }
+            
+            ArticleDraftSheet(viewModel: viewModel)
+                .transition(.move(edge: .bottom))
+                .animation(.easeInOut, value: viewModel.isDraftSheetPresent)
         }
         .navigationBarBackButtonHidden()
+        .animation(.easeInOut(duration: 0.3), value: viewModel.isEmptyDraftEntered)
         .animation(.easeInOut(duration: 0.3), value: viewModel.isEmptyTitleEntered)
         .onAppear {
             Task {
@@ -208,8 +213,4 @@ struct ArticleView: View {
             }
         }
     }
-}
-
-#Preview {
-    ArticleView(mainTabViewModel: MainTabViewModel())
 }

--- a/Wastory/Wastory/View/ArticleView/ArticleView.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleView.swift
@@ -164,6 +164,7 @@ struct ArticleView: View {
                         .focusedValue(\.richTextContext, viewModel.context)
                         .focused($isTextFocused)
                         .padding(.horizontal, 18)
+                        .id(viewModel.resetEditor)
                 }
                 RichTextKeyboardToolbar(
                     context: viewModel.context,

--- a/Wastory/Wastory/View/ArticleView/RichTextImageHandler.swift
+++ b/Wastory/Wastory/View/ArticleView/RichTextImageHandler.swift
@@ -1,0 +1,70 @@
+//
+//  RichTextImageHandler.swift
+//  Wastory
+//
+//  Created by mujigae on 1/29/25.
+//
+
+import SwiftUI
+import Kingfisher
+
+@MainActor
+class RichTextImageHandler {
+    // 이미지를 URL로 변환하고 NSAttributedString을 수정하는 함수
+    static func convertImagesToURLs(_ attributedString: NSAttributedString) async -> NSAttributedString {
+        let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
+        
+        attributedString.enumerateAttribute(.attachment, in: NSRange(location: 0, length: attributedString.length)) { value, range, _ in
+            guard let attachment = value as? NSTextAttachment,
+                  let image = attachment.image else { return }
+            
+            // 이미지 업로드 및 URL 획득
+            Task {
+                do {
+                    let imageURL = try await NetworkRepository.shared.postImage(image)
+                    let urlAttachment = NSTextAttachment()
+                    urlAttachment.bounds = attachment.bounds
+                    
+                    // URL을 저장할 커스텀 속성 추가
+                    let attributes: [NSAttributedString.Key: Any] = [
+                        .attachment: urlAttachment,
+                        .customImageURL: imageURL
+                    ]
+                    
+                    let replacementString = NSAttributedString(string: "📷", attributes: attributes)
+                    mutableAttributedString.replaceCharacters(in: range, with: replacementString)
+                } catch {
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
+        }
+        
+        return mutableAttributedString
+    }
+    
+    // URL로부터 이미지를 다운로드하여 NSAttributedString을 복원하는 함수
+    static func restoreImagesFromURLs(_ attributedString: NSAttributedString) async -> NSAttributedString {
+        let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
+        
+        attributedString.enumerateAttribute(.customImageURL, in: NSRange(location: 0, length: attributedString.length)) { value, range, _ in
+            guard let imageURL = value as? String else { return }
+            
+            Task {
+                if let image = try? await KingfisherManager.shared.retrieveImage(with: .network(imageURL as! Resource)).image {
+                    let imageAttachment = NSTextAttachment()
+                    imageAttachment.image = image
+                    
+                    let replacementString = NSAttributedString(attachment: imageAttachment)
+                    mutableAttributedString.replaceCharacters(in: range, with: replacementString)
+                }
+            }
+        }
+        
+        return mutableAttributedString
+    }
+}
+
+// 커스텀 속성 키 정의
+extension NSAttributedString.Key {
+    static let customImageURL = NSAttributedString.Key("customImageURL")
+}

--- a/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
+++ b/Wastory/Wastory/View/SignView/SignUpStep2EmailView.swift
@@ -244,25 +244,6 @@ struct SignUpStep2EmailView: View {
                     }
                     
                     ZStack {
-                        /*
-                        NavigationLink(destination: SignUpStep3PasswordView()) {
-                            Text("다음")
-                                .font(.system(size: 16, weight: .regular))
-                                .foregroundStyle(.black)
-                                .padding(.vertical, 16)
-                                .frame(maxWidth: .infinity, idealHeight: 51)
-                                .background(Color.kakaoYellow)
-                                .cornerRadius(6)
-                        }
-                        .padding(.horizontal, 20)
-                        .disabled(!viewModel.isVerificationSuccessful())
-                        .simultaneousGesture(
-                            TapGesture().onEnded {
-                                UserInfoRepository.shared.setUserID(userID: viewModel.email)    // UserID (email) 결정
-                            }
-                        )
-                        .opacity(viewModel.isVerificationSuccessful() ? 1 : 0)*/
-                        
                         Button {
                             Task {
                                 await viewModel.verifyCode()

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleSettingViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleSettingViewModel.swift
@@ -136,7 +136,7 @@ import RichTextKit
                 try await NetworkRepository.shared.postArticle(
                     title: title,
                     content: htmlText,
-                    description: String(text.string.prefix(20)),
+                    description: String(text.string.prefix(80)),
                     main_image_url: mainImageURL ?? "",
                     categoryID: category.id,
                     homeTopicID: homeTopic.id,

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
@@ -20,17 +20,25 @@ import RichTextKit
     var isEmptyTitleEntered: Bool = false
     
     private var page: Int = 1
+    private var isPageEnded: Bool = false
     var draftsCount: Int = 0
-    var drafts: [Draft] = []
+    var drafts: [DraftDto] = []
     var currentDraftID: Int = -1
+    var isDraftSheetPresent: Bool = false
+    
+    init(title: String, text: NSAttributedString) {
+        self.title = title
+        self.text = text
+    }
     
     func resetView() async {
         page = 1
+        isPageEnded = false
         await getDrafts()
     }
     
     func getDrafts() async {
-        if drafts.count < draftsCount {
+        if !isPageEnded {
             do {
                 let response = try await NetworkRepository.shared.getDraftsInBlog(
                     blogID: UserInfoRepository.shared.getBlogID(),
@@ -44,6 +52,9 @@ import RichTextKit
                     drafts += response.drafts
                 }
                 page += 1
+                if drafts.count == draftsCount {
+                    isPageEnded = true
+                }
             } catch {
                 print("Error: \(error.localizedDescription)")
             }
@@ -55,11 +66,41 @@ import RichTextKit
     }
     
     func getDraft(draftID: Int) async {
+        /*
         do {
             let response = try await NetworkRepository.shared.getDraft(draftID: draftID)
             title = response.title
             if let loadedText = HTMLTotext(response.content) {
                 text = loadedText
+                print("로드 성공: \(text.string)")
+                print(text)
+            }
+            currentDraftID = response.id
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }*/
+        
+        /*
+        do {
+            let response = try await NetworkRepository.shared.getDraft(draftID: draftID)
+            title = response.title
+            if let loadedText = RTFTotext(response.content) {
+                text = loadedText
+                print("로드 성공: \(text.string)")
+                print(text)
+            }
+            currentDraftID = response.id
+        } catch {
+            print("Error: \(error.localizedDescription)")
+        }*/
+        
+        do {
+            let response = try await NetworkRepository.shared.getDraft(draftID: draftID)
+            title = response.title
+            if let loadedText = DataTotext(response.content) {
+                text = loadedText
+                print("로드 성공: \(text.string)")
+                print(text)
             }
             currentDraftID = response.id
         } catch {
@@ -68,6 +109,7 @@ import RichTextKit
     }
     
     func storeDraft() async {
+        /*
         if let htmlText = textToHTML(text) {
             if currentDraftID < 0 {
                 do {
@@ -83,7 +125,46 @@ import RichTextKit
                     print("Error: \(error.localizedDescription)")
                 }
             }
+        }*/
+        
+        /*
+        if let rtfText = textToRTF(text) {
+            if currentDraftID < 0 {
+                do {
+                    let response = try await NetworkRepository.shared.postDraft(title: title, content: rtfText)
+                    currentDraftID = response.id
+                } catch {
+                    print("Error: \(error.localizedDescription)")
+                }
+            } else {
+                do {
+                    try await NetworkRepository.shared.patchDraft(title: title, content: rtfText, draftID: currentDraftID)
+                } catch {
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
+        }*/
+        
+        if let dataText = textToData(text) {
+            if currentDraftID < 0 {
+                do {
+                    let response = try await NetworkRepository.shared.postDraft(title: title, content: dataText)
+                    currentDraftID = response.id
+                } catch {
+                    print("Error: \(error.localizedDescription)")
+                }
+            } else {
+                do {
+                    try await NetworkRepository.shared.patchDraft(title: title, content: dataText, draftID: currentDraftID)
+                } catch {
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
         }
+    }
+    
+    func toggleIsDraftSheetPresent() {
+        isDraftSheetPresent.toggle()
     }
     
     // MARK: - Converters
@@ -109,7 +190,10 @@ import RichTextKit
         do {
             let htmlData = try text.data(
                 from: NSRange(location: 0, length: text.length),
-                documentAttributes: [.documentType: NSAttributedString.DocumentType.html]
+                documentAttributes: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue
+                ]
             )
             if let htmlString = String(data: htmlData, encoding: .utf8) {
                 return htmlString
@@ -117,6 +201,54 @@ import RichTextKit
         }
         catch {
             print("Error convertnig Rich Text to HTML: \(error)")
+        }
+        return nil
+    }
+    
+    func textToRTF(_ text: NSAttributedString) -> String? {
+        do {
+            let rtfData = try text.data(
+                from: NSRange(location: 0, length: text.length),
+                documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf])
+            return rtfData.base64EncodedString()
+        }
+        catch {
+            print("Error convertnig Rich Text to RTF: \(error)")
+        }
+        return nil
+    }
+    
+    func RTFTotext(_ rtfString: String) -> NSAttributedString? {
+        do {
+            let rtfData = Data(base64Encoded: rtfString)
+            return try NSAttributedString(
+                data: rtfData!,
+                options: [.documentType: NSAttributedString.DocumentType.rtf],
+                documentAttributes: nil)
+        }
+        catch {
+            print("Error convertnig RTF to Rich Text: \(error)")
+        }
+        return nil
+    }
+    
+    func textToData(_ text: NSAttributedString) -> String? {
+        do {
+            let data = try NSKeyedArchiver.archivedData(withRootObject: text, requiringSecureCoding: false)
+            return data.base64EncodedString()
+        } catch {
+            print("Failed to archive NSAttributedString: \(error)")
+            return nil
+        }
+    }
+    
+    func DataTotext(_ data: String) -> NSAttributedString? {
+        if let text = Data(base64Encoded: data) {
+            do {
+                return try NSAttributedString(data: text, format: .archivedData)
+            } catch {
+                print("Failed to load NSAttributedString: \(error)")
+            }
         }
         return nil
     }

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
@@ -78,7 +78,7 @@ import RichTextKit
             let response = try await NetworkRepository.shared.getDraft(draftID: draftID)
             title = response.title
             if let loadedText = DataTotext(response.content) {
-                let restoredText = await RichTextImageHandler.restoreImagesFromURLs(loadedText)
+                let restoredText = await RichTextImageHandler.restoreImage(loadedText)
                 text = restoredText
             }
             else {
@@ -92,20 +92,20 @@ import RichTextKit
     }
     
     func storeDraft() async {
-        let processedText = await RichTextImageHandler.convertImagesToURLs(text)
+        let processedText = await RichTextImageHandler.convertImage(text)
         if let dataText = textToData(processedText) {
             if currentDraftID < 0 {
                 do {
                     let response = try await NetworkRepository.shared.postDraft(title: title, content: dataText)
                     currentDraftID = response.id
                 } catch {
-                    print("Error: \(error.localizedDescription)")
+                    print("Store Error: \(error.localizedDescription)")
                 }
             } else {
                 do {
                     try await NetworkRepository.shared.patchDraft(title: title, content: dataText, draftID: currentDraftID)
                 } catch {
-                    print("Error: \(error.localizedDescription)")
+                    print("Patch Error: \(error.localizedDescription)")
                 }
             }
         }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

-[O] 기능 추가
 -[] 기능 삭제
 -[] 버그 수정
 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feature/store-draft  -> main

### 변경 사항 

임시 저장 기능 가능
글에 이미지 첨부 가능 및 서버와 연결도 완료

### 추후 보완 사항

발행된 글에서 저장된 텍스트 불러오는 기능 필요 (필수 기능)
임시 저장은 100개까지만 가능 (후순위)
이미지 크기 변환 기능 (있으면 좋은데 매우 어려울 것으로 예상: 찾아도 잘 나오지 않음)
(추가로 현재 데이터를 보내다 보니 로그 메세지가 너무 길어져 시뮬레이터가 자꾸 멈춰 일부 로그를 삭제했습니다.)

참고 영상

https://github.com/user-attachments/assets/1dd78f51-b657-463f-b03d-d54dbd2e3663

