### PR TITLE
Feat: Implement Post View with loaded data

### DIFF
--- a/Wastory/Wastory/Info.plist
+++ b/Wastory/Wastory/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>이 앱은 사진을 촬영하거나 이미지를 첨부하는 기능을 위해 카메라에 접근합니다.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Wastory/Wastory/View/ArticleView/ArticleDraftDeleteSheet.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleDraftDeleteSheet.swift
@@ -1,0 +1,57 @@
+//
+//  ArticleDraftDeleteSheet.swift
+//  Wastory
+//
+//  Created by mujigae on 1/29/25.
+//
+
+import SwiftUI
+
+struct ArticleDraftDeleteSheet: View {
+    @Bindable var viewModel: ArticleViewModel
+    
+    var body: some View {
+        ZStack {
+            // MARK: Background Dimming
+            (viewModel.isDraftDeleteSheetPresent ? Color.sheetOuterBackgroundColor : Color.clear)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    viewModel.toggleIsDraftDeleteSheetPresent()
+                }
+
+            VStack {
+                Spacer()
+                if viewModel.isDraftDeleteSheetPresent {
+                    let sheetHeight: CGFloat = UIScreen.main.bounds.height * 0.12
+                    
+                    ZStack {
+                        VStack(alignment: .leading, spacing: 0) {
+                            Spacer()
+                                .frame(height: 30)
+                            Button {
+                                viewModel.isDraftDeleteSheetPresent = false
+                                viewModel.showDeleteAlert = true
+                            } label: {
+                                HStack {
+                                    Text("삭제하기")
+                                        .font(.system(size: 15, weight: .light))
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 20)
+                            }
+                            Spacer()
+                        }
+                        .frame(height: sheetHeight)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.white)
+                        .cornerRadius(20)
+                    }
+                    .background(Color.clear)
+                    .transition(.move(edge: .bottom))
+                    .animation(.easeInOut, value: viewModel.isDraftDeleteSheetPresent)
+                }
+            }
+        }
+        .ignoresSafeArea()
+    }
+}

--- a/Wastory/Wastory/View/ArticleView/ArticleDraftSheet.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleDraftSheet.swift
@@ -68,6 +68,10 @@ struct ArticleDraftSheet: View {
                     .animation(.easeInOut, value: viewModel.isDraftSheetPresent)
                 }
             }
+            
+            ArticleDraftDeleteSheet(viewModel: viewModel)
+                .transition(.move(edge: .bottom))
+                .animation(.easeInOut, value: viewModel.isDraftDeleteSheetPresent)
         }
         .ignoresSafeArea()
     }
@@ -97,6 +101,13 @@ struct ArticleDraftSheet: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 20)
+        .simultaneousGesture(LongPressGesture().onEnded { _ in
+            withAnimation {
+                viewModel.deleteDraftID = draft.id
+                viewModel.isDraftDeleteSheetPresent = true
+            }
+        })
+        .disabled(viewModel.isDraftDeleteSheetPresent)
         SettingDivider(thickness: 1)
     }
 }

--- a/Wastory/Wastory/View/ArticleView/ArticleView.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleView.swift
@@ -161,9 +161,7 @@ struct ArticleView: View {
                             Spacer()
                         }
                     }
-                    RichTextEditor(text: $viewModel.text, context: viewModel.context) {
-                        $0.imageConfiguration.maxImageSize = (width: .points(200), height: .points(200))
-                    }
+                    RichTextEditor(text: $viewModel.text, context: viewModel.context)
                         .focusedValue(\.richTextContext, viewModel.context)
                         .focused($isTextFocused)
                         .padding(.horizontal, 18)

--- a/Wastory/Wastory/View/ArticleView/ArticleView.swift
+++ b/Wastory/Wastory/View/ArticleView/ArticleView.swift
@@ -154,35 +154,43 @@ struct ArticleView: View {
                 Spacer()
                     .frame(height: 20)
                 
-                // MARK: Title TextField
-                TextField("제목", text: $viewModel.title)
-                    .font(.system(size: 26, weight: .regular))
-                    .foregroundStyle(Color.primaryLabelColor)
-                    .focused($isTitleFocused)
-                    .autocapitalization(.none)
-                    .padding(.horizontal, 23)
-                
-                Spacer()
-                    .frame(height: 10)
-                
-                // MARK: Contents TextField
-                ZStack(alignment: .topLeading) {
-                    if viewModel.text.string.isEmpty {
-                        HStack {
-                            Text("내용을 입력해주세요.")
-                                .font(.system(size: 15, weight: .regular))
-                                .foregroundStyle(Color.promptLabelColor)
-                                .padding(.horizontal, 26)
-                                .padding(.top, 9)
-                            Spacer()
+                ScrollView {
+                    // MARK: Title TextField
+                    TextField("제목", text: $viewModel.title)
+                        .font(.system(size: 26, weight: .regular))
+                        .foregroundStyle(Color.primaryLabelColor)
+                        .focused($isTitleFocused)
+                        .autocapitalization(.none)
+                        .padding(.horizontal, 23)
+                    
+                    Spacer()
+                        .frame(height: 10)
+                    
+                    // MARK: Contents TextField
+                    ZStack(alignment: .topLeading) {
+                        if viewModel.text.string.isEmpty {
+                            HStack {
+                                Text("내용을 입력해주세요.")
+                                    .font(.system(size: 15, weight: .regular))
+                                    .foregroundStyle(Color.promptLabelColor)
+                                    .padding(.horizontal, 26)
+                                    .padding(.top, 9)
+                                Spacer()
+                            }
                         }
+                        RichTextEditor(text: $viewModel.text, context: viewModel.context)
+                            .focusedValue(\.richTextContext, viewModel.context)
+                            .focused($isTextFocused)
+                            .frame(height: 1000)
+                            .padding(.horizontal, 18)
+                            .id(viewModel.resetEditor)
                     }
-                    RichTextEditor(text: $viewModel.text, context: viewModel.context)
-                        .focusedValue(\.richTextContext, viewModel.context)
-                        .focused($isTextFocused)
-                        .padding(.horizontal, 18)
-                        .id(viewModel.resetEditor)
+                    Spacer()
                 }
+            }
+            
+            VStack {
+                Spacer()
                 RichTextKeyboardToolbar(
                     context: viewModel.context,
                     leadingButtons: { _ in },
@@ -195,7 +203,7 @@ struct ArticleView: View {
                     },
                     formatSheet: { $0 }
                 )
-                Spacer()
+                .padding(.bottom, 30)
             }
             
             if isPickerSelectorPresent {

--- a/Wastory/Wastory/View/ArticleView/RichTextHandler.swift
+++ b/Wastory/Wastory/View/ArticleView/RichTextHandler.swift
@@ -1,0 +1,98 @@
+//
+//  RichTextHandler.swift
+//  Wastory
+//
+//  Created by mujigae on 1/29/25.
+//
+
+import SwiftUI
+
+class RichTextHandler {
+    // MARK: - Converters
+    // MARK: Main Converter
+    static func textToData(_ text: NSAttributedString) -> String? {
+        do {
+            let data = try NSKeyedArchiver.archivedData(withRootObject: text, requiringSecureCoding: false)
+            return data.base64EncodedString()
+        } catch {
+            print("Failed to archive NSAttributedString: \(error)")
+            return nil
+        }
+    }
+    
+    static func DataTotext(_ data: String) -> NSAttributedString? {
+        if let text = Data(base64Encoded: data) {
+            do {
+                return try NSAttributedString(data: text, format: .archivedData)
+            } catch {
+                print("Failed to load NSAttributedString: \(error)")
+            }
+        }
+        return nil
+    }
+    
+    // MARK: Sub Converter (may not use)
+    static func HTMLTotext(_ htmlString: String) -> NSAttributedString? {
+        guard let htmlData = htmlString.data(using: .utf8) else { return nil }
+        do {
+            let attributedString = try NSAttributedString(
+                data: htmlData,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue
+                ],
+                documentAttributes: nil
+            )
+            return attributedString
+        } catch {
+            print("Error converting HTML to NSAttributedString: \(error)")
+        }
+        return nil
+    }
+    
+    static func textToHTML(_ text: NSAttributedString) -> String? {
+        do {
+            let htmlData = try text.data(
+                from: NSRange(location: 0, length: text.length),
+                documentAttributes: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue
+                ]
+            )
+            if let htmlString = String(data: htmlData, encoding: .utf8) {
+                return htmlString
+            }
+        }
+        catch {
+            print("Error convertnig Rich Text to HTML: \(error)")
+        }
+        return nil
+    }
+    
+    static func textToRTF(_ text: NSAttributedString) -> String? {
+        do {
+            let rtfData = try text.data(
+                from: NSRange(location: 0, length: text.length),
+                documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf])
+            return rtfData.base64EncodedString()
+        }
+        catch {
+            print("Error convertnig Rich Text to RTF: \(error)")
+        }
+        return nil
+    }
+    
+    static func RTFTotext(_ rtfString: String) -> NSAttributedString? {
+        do {
+            let rtfData = Data(base64Encoded: rtfString)
+            return try NSAttributedString(
+                data: rtfData!,
+                options: [.documentType: NSAttributedString.DocumentType.rtf],
+                documentAttributes: nil)
+        }
+        catch {
+            print("Error convertnig RTF to Rich Text: \(error)")
+        }
+        return nil
+    }
+}

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import RichTextKit
 
 struct PostView: View {
     let postID: Int
@@ -15,6 +16,7 @@ struct PostView: View {
     @Environment(\.dismiss) private var dismiss
 //    @Environment(\.contentViewModel) var contentViewModel
     
+    @FocusState private var isTextFocused: Bool
     
     var body: some View {
         VStack(spacing: 0) {
@@ -91,11 +93,16 @@ struct PostView: View {
                             .frame(height: 60)
                         
                         // MARK: Content
+                        /*
                         Text(viewModel.post.content ?? "")
                             .font(.system(size: 20, weight: .light))
                             .foregroundStyle(Color.primaryLabelColor)
                             .padding(.horizontal, 20)
-                        
+                        */
+                        RichTextViewer(viewModel.text)
+                            .id(viewModel.isTextLoaded)
+                            .frame(height: 1000)
+                            .padding(.horizontal, 20)
                         
                         Spacer()
                             .frame(height: 30)
@@ -230,6 +237,9 @@ struct PostView: View {
                 }
                 Task {
                     await viewModel.getIsLiked()
+                }
+                Task {
+                    await viewModel.loadText()
                 }
             }
             if toComment {

--- a/Wastory/Wastory/View/ContentView/PostView/PostView.swift
+++ b/Wastory/Wastory/View/ContentView/PostView/PostView.swift
@@ -36,6 +36,7 @@ struct PostView: View {
                             }
                     }
                     .frame(height: 0)
+                    Spacer()
                     VStack(alignment: .leading, spacing: 0) {
                         Spacer()
                             .frame(height: 100)
@@ -93,27 +94,22 @@ struct PostView: View {
                             .frame(height: 60)
                         
                         // MARK: Content
-                        /*
-                        Text(viewModel.post.content ?? "")
-                            .font(.system(size: 20, weight: .light))
-                            .foregroundStyle(Color.primaryLabelColor)
-                            .padding(.horizontal, 20)
-                        */
                         RichTextViewer(viewModel.text)
-                            .id(viewModel.isTextLoaded)
-                            .frame(height: 1000)
+                            .frame(height: viewModel.textHeight)
                             .padding(.horizontal, 20)
+                            .id(viewModel.isTextLoaded)
                         
                         Spacer()
                             .frame(height: 30)
                         
                         Divider()
                             .foregroundStyle(Color.secondaryLabelColor)
+                        Spacer()
                     }
                     .background(Color.white)
                     // TODO: 태그 버튼 추가하기
                     
-                    
+                    Spacer()
                     
                     
                     //Blog 세부설명 및 구독버튼
@@ -241,10 +237,10 @@ struct PostView: View {
                 Task {
                     await viewModel.loadText()
                 }
-            }
-            if toComment {
-                viewModel.showComments.toggle()
-                toComment = false
+                if toComment {
+                    viewModel.showComments.toggle()
+                    toComment = false
+                }
             }
         }
         .ignoresSafeArea(edges: .all)

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleSettingViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleSettingViewModel.swift
@@ -106,16 +106,6 @@ import RichTextKit
     }
     
     // MARK: - Posting
-    func textToData(_ text: NSAttributedString) -> String? {
-        do {
-            let data = try NSKeyedArchiver.archivedData(withRootObject: text, requiringSecureCoding: false)
-            return data.base64EncodedString()
-        } catch {
-            print("Failed to archive NSAttributedString: \(error)")
-            return nil
-        }
-    }
-    
     func postArticle() async {
         if let image = mainImage {
             do {
@@ -127,7 +117,7 @@ import RichTextKit
         }
         
         let processedText = await RichTextImageHandler.convertImage(text)
-        if let dataText = textToData(processedText) {
+        if let dataText = RichTextHandler.textToData(processedText) {
             do {
                 try await NetworkRepository.shared.postArticle(
                     title: title,

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
@@ -19,6 +19,8 @@ import RichTextKit
     let cautionDuration: Double = 1.6
     var isEmptyDraftEntered: Bool = false
     var isEmptyTitleEntered: Bool = false
+    var isDraftSaved: Bool = false
+    var isDraftDeleted: Bool = false
     
     private var page: Int = 1
     private var isPageEnded: Bool = false
@@ -27,7 +29,9 @@ import RichTextKit
     var currentDraftID: Int = -1
     var isDraftSheetPresent: Bool = false
     var resetEditor: Bool = false
-    var isDraftSaved: Bool = false
+    var deleteDraftID: Int = -1
+    var isDraftDeleteSheetPresent: Bool = false
+    var showDeleteAlert: Bool = false
     
     var inputImage: UIImage?
     var isGalleryPickerPresent: Bool = false
@@ -54,6 +58,7 @@ import RichTextKit
         page = 1
         isPageEnded = false
         await getDrafts()
+        deleteDraftID = -1
     }
     
     func getDrafts() async {
@@ -122,7 +127,22 @@ import RichTextKit
         }
     }
     
+    func deleteDraft() async {
+        do {
+            try await NetworkRepository.shared.deleteDraft(draftID: deleteDraftID)
+            await resetView()
+            currentDraftID = -1
+            deleteDraftID = -1
+        } catch {
+            print("Delete Draft Error: \(error.localizedDescription)")
+        }
+    }
+    
     func toggleIsDraftSheetPresent() {
         isDraftSheetPresent.toggle()
+    }
+    
+    func toggleIsDraftDeleteSheetPresent() {
+        isDraftDeleteSheetPresent.toggle()
     }
 }

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
@@ -27,6 +27,7 @@ import RichTextKit
     var currentDraftID: Int = -1
     var isDraftSheetPresent: Bool = false
     var resetEditor: Bool = false
+    var isDraftSaved: Bool = false
     
     var inputImage: UIImage?
     var isGalleryPickerPresent: Bool = false

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
@@ -35,7 +35,16 @@ import RichTextKit
     
     func insertImage(inputImage: UIImage, context: RichTextContext) {
         let cursorLocation = context.selectedRange.location
-        let insertion = RichTextInsertion<UIImage>.image(inputImage, at: cursorLocation, moveCursor: true)
+        
+        let imageAspectRatio = inputImage.size.height / inputImage.size.width
+        let height = imageAspectRatio * screenWidth
+
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: screenWidth, height: height))
+        let resizedImage = renderer.image { _ in
+            inputImage.draw(in: CGRect(origin: .zero, size: CGSize(width: screenWidth, height: height)))
+        }
+        
+        let insertion = RichTextInsertion<UIImage>.image(resizedImage, at: cursorLocation, moveCursor: true)
         let action = RichTextAction.pasteImage(insertion)
         context.handle(action)
     }

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
@@ -31,6 +31,7 @@ import RichTextKit
     var inputImage: UIImage?
     var isGalleryPickerPresent: Bool = false
     var isCameraPickerPresent: Bool = false
+    let screenWidth: CGFloat = UIScreen.main.bounds.width - 40
     
     func insertImage(inputImage: UIImage, context: RichTextContext) {
         let cursorLocation = context.selectedRange.location
@@ -78,7 +79,7 @@ import RichTextKit
             let response = try await NetworkRepository.shared.getDraft(draftID: draftID)
             title = response.title
             if let loadedText = RichTextHandler.DataTotext(response.content) {
-                let restoredText = await RichTextImageHandler.restoreImage(loadedText)
+                let restoredText = await RichTextImageHandler.restoreImage(loadedText, screenWidth: screenWidth)
                 text = restoredText
             }
             else {

--- a/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ArticleViewModel/ArticleViewModel.swift
@@ -77,7 +77,7 @@ import RichTextKit
         do {
             let response = try await NetworkRepository.shared.getDraft(draftID: draftID)
             title = response.title
-            if let loadedText = DataTotext(response.content) {
+            if let loadedText = RichTextHandler.DataTotext(response.content) {
                 let restoredText = await RichTextImageHandler.restoreImage(loadedText)
                 text = restoredText
             }
@@ -93,7 +93,7 @@ import RichTextKit
     
     func storeDraft() async {
         let processedText = await RichTextImageHandler.convertImage(text)
-        if let dataText = textToData(processedText) {
+        if let dataText = RichTextHandler.textToData(processedText) {
             if currentDraftID < 0 {
                 do {
                     let response = try await NetworkRepository.shared.postDraft(title: title, content: dataText)
@@ -113,93 +113,5 @@ import RichTextKit
     
     func toggleIsDraftSheetPresent() {
         isDraftSheetPresent.toggle()
-    }
-    
-    // MARK: - Converters
-    // MARK: Main Converter
-    func textToData(_ text: NSAttributedString) -> String? {
-        do {
-            let data = try NSKeyedArchiver.archivedData(withRootObject: text, requiringSecureCoding: false)
-            return data.base64EncodedString()
-        } catch {
-            print("Failed to archive NSAttributedString: \(error)")
-            return nil
-        }
-    }
-    
-    func DataTotext(_ data: String) -> NSAttributedString? {
-        if let text = Data(base64Encoded: data) {
-            do {
-                return try NSAttributedString(data: text, format: .archivedData)
-            } catch {
-                print("Failed to load NSAttributedString: \(error)")
-            }
-        }
-        return nil
-    }
-    
-    // MARK: Sub Converter (may not use)
-    func HTMLTotext(_ htmlString: String) -> NSAttributedString? {
-        guard let htmlData = htmlString.data(using: .utf8) else { return nil }
-        do {
-            let attributedString = try NSAttributedString(
-                data: htmlData,
-                options: [
-                    .documentType: NSAttributedString.DocumentType.html,
-                    .characterEncoding: String.Encoding.utf8.rawValue
-                ],
-                documentAttributes: nil
-            )
-            return attributedString
-        } catch {
-            print("Error converting HTML to NSAttributedString: \(error)")
-        }
-        return nil
-    }
-    
-    func textToHTML(_ text: NSAttributedString) -> String? {
-        do {
-            let htmlData = try text.data(
-                from: NSRange(location: 0, length: text.length),
-                documentAttributes: [
-                    .documentType: NSAttributedString.DocumentType.html,
-                    .characterEncoding: String.Encoding.utf8.rawValue
-                ]
-            )
-            if let htmlString = String(data: htmlData, encoding: .utf8) {
-                return htmlString
-            }
-        }
-        catch {
-            print("Error convertnig Rich Text to HTML: \(error)")
-        }
-        return nil
-    }
-    
-    func textToRTF(_ text: NSAttributedString) -> String? {
-        do {
-            let rtfData = try text.data(
-                from: NSRange(location: 0, length: text.length),
-                documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf])
-            return rtfData.base64EncodedString()
-        }
-        catch {
-            print("Error convertnig Rich Text to RTF: \(error)")
-        }
-        return nil
-    }
-    
-    func RTFTotext(_ rtfString: String) -> NSAttributedString? {
-        do {
-            let rtfData = Data(base64Encoded: rtfString)
-            return try NSAttributedString(
-                data: rtfData!,
-                options: [.documentType: NSAttributedString.DocumentType.rtf],
-                documentAttributes: nil)
-        }
-        catch {
-            print("Error convertnig RTF to Rich Text: \(error)")
-        }
-        return nil
     }
 }

--- a/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
@@ -9,7 +9,9 @@
 
 import SwiftUI
 import Observation
+import RichTextKit
 
+@MainActor
 @Observable final class PostViewModel {
     var post: Post = Post.defaultPost
     var blog: Blog = Blog.defaultBlog
@@ -81,6 +83,35 @@ import Observation
         }
     }
     
+    // MARK: - Rendering Content
+    var text = NSAttributedString()
+    var context = RichTextContext()
+    var isTextLoaded: Bool = false
+    
+    func DataTotext(_ data: String) -> NSAttributedString? {
+        if let text = Data(base64Encoded: data) {
+            do {
+                return try NSAttributedString(data: text, format: .archivedData)
+            } catch {
+                print("Failed to load NSAttributedString: \(error)")
+            }
+        }
+        return nil
+    }
+    
+    func loadText() async {
+        if let content = post.content {
+            if let loadedText = RichTextHandler.DataTotext(content) {
+                let restoredText = await RichTextImageHandler.restoreImage(loadedText)
+                text = restoredText
+                isTextLoaded = true
+                print("restored!: ", text)
+            }
+            else {
+                print("Error: Failed to load text data")
+            }
+        }
+    }
     
     
     func deleteSelfPost(at List: inout [Post]) {

--- a/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
+++ b/Wastory/Wastory/ViewModel/ContentViewModel/PostViewModel/PostViewModel.swift
@@ -88,6 +88,7 @@ import RichTextKit
     var context = RichTextContext()
     var textHeight: CGFloat = 0
     var isTextLoaded: Bool = false
+    let screenWidth: CGFloat = UIScreen.main.bounds.width - 40
     
     func DataTotext(_ data: String) -> NSAttributedString? {
         if let text = Data(base64Encoded: data) {
@@ -103,16 +104,9 @@ import RichTextKit
     func loadText() async {
         if let content = post.content {
             if let loadedText = RichTextHandler.DataTotext(content) {
-                let restoredText = await RichTextImageHandler.restoreImage(loadedText)
+                let restoredText = await RichTextImageHandler.restoreImage(loadedText, screenWidth: screenWidth)
                 text = restoredText
-                /*
-                textHeight = text.boundingRect(
-                    with: CGSize(width: UIScreen.main.bounds.width - 40, height: .greatestFiniteMagnitude),
-                    options: [.usesLineFragmentOrigin, .usesFontLeading],
-                    context: nil).height + 30*/
-                textHeight = calculateHeight(text: text, screenWidth: UIScreen.main.bounds.width - 40) + 30
-                print("width: ", UIScreen.main.bounds.width - 40)
-                print("height: ", textHeight)
+                textHeight = calculateHeight(text: text, screenWidth: screenWidth) + 30
                 isTextLoaded = true
             }
             else {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

-[O] 기능 추가
 -[] 기능 삭제
 -[] 버그 수정
 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feature/post-data-load  -> main

### 변경 사항 

임시 저장할 때 이미지 삽입 가능 (사진은 화면에 맞춰서 삽입)
임시 저장 삭제 기능 추가
임시 저장을 불러 와도 이미지 사이즈 화면에 맞춰서 유지
포스트 뷰 데이터 렌더링 기능 추가 (글의 크기를 계산하여 딱 맞게 하도록 하였고 이미지는 화면 가로에 맞도록 구현)

### 추후 보완 사항

대표 이미지 없을 경우 첫 이미지로 설정
서버 API 바뀌면 이미지 url 리스트 만들어서 보내는 기능 추가 필요

참고 영상

https://github.com/user-attachments/assets/a275a599-d707-4fe8-977e-d3c787966fea

