### PR TITLE
Fix: GeustBook comment disable

### DIFF
--- a/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentView.swift
@@ -147,7 +147,7 @@ struct CommentView: View {
                     }
                     
                     ZStack {
-                        if postViewModel.post.commentsEnabled == 1 {
+                        if postViewModel.post.commentsEnabled == 1 || postID == nil {
                             HStack(spacing: 0) {
                                 if viewModel.isWritingCommentEmpty() {
                                     Text("내용을 입력하세요")

--- a/Wastory/Wastory/View/NotificationView/NotificationView.swift
+++ b/Wastory/Wastory/View/NotificationView/NotificationView.swift
@@ -110,6 +110,7 @@ struct NotificationView: View {
                     await viewModel.deleteNotificationRead()
                     viewModel.resetPage()
                     await viewModel.getNotifications()
+                    mainTabViewModel.prevFirstNotificationID = viewModel.notifications.first?.id ?? -2
                 }
             }
         } message: {

--- a/Wastory/Wastory/ViewModel/MainTabViewModel.swift
+++ b/Wastory/Wastory/ViewModel/MainTabViewModel.swift
@@ -53,16 +53,22 @@ import Observation
     //MARK: Notification Icon
     var isNotificationUnread: Bool = false
     
+    var prevFirstNotificationID: Int = -1
+    
     
     func setIsNotificationUnread() async {
         do {
             let response = try await NetworkRepository.shared.getNotifications(page: 1, type: nil)
-            print("set")
             if response.isEmpty {
                 isNotificationUnread = false
             } else {
-                if let _ = response.first(where: { !$0.checked }) {
-                    isNotificationUnread = true
+                if prevFirstNotificationID == response.first!.id && !isNotificationUnread {
+                    isNotificationUnread = false
+                } else {
+                    prevFirstNotificationID = response.first!.id
+                    if let _ = response.first(where: { !$0.checked }) {
+                        isNotificationUnread = true
+                    }
                 }
             }
         } catch {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
 -[] 기능 삭제
 -[O] 버그 수정
 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Fix: GeustBook comment disable -> main

### 변경 사항 
방명록의 댓글 비활성화 현상 수정

알림 아이콘 표시 로직 수정.
이전의 첫 알림 id를 저장해 mainTabView가 onAppear 할 때 마다 새로운 알림이 있는지 확인하는 것 추가
notification delete할 때 mainTbaView의 prevNotificationID를 재설정

### 추후 보완 사항
