### PR TITLE
Feat: Fix comment cell navigation error by deleting default blog id

### DIFF
--- a/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
+++ b/Wastory/Wastory/View/ContentView/CommentView/CommentCell.swift
@@ -46,7 +46,7 @@ struct CommentCell: View {
                     
                     VStack(alignment: .leading, spacing: 0) {
                         HStack(spacing: 5) {
-                            NavigateToBlogViewButton(tempBlog().id) {
+                            NavigateToBlogViewButton(comment.blogID) {
                                 Text(comment.userName)
                                     .font(.system(size: 14, weight: .semibold))
                                     .foregroundStyle(Color.primaryLabelColor)
@@ -113,7 +113,7 @@ struct CommentCell: View {
                         
                         VStack(alignment: .leading, spacing: 0) {
                             HStack(spacing: 5) {
-                                NavigateToBlogViewButton(tempBlog().id) {
+                                NavigateToBlogViewButton(comment.blogID) {
                                     Text(comment.userName)
                                         .font(.system(size: 14, weight: .semibold))
                                         .foregroundStyle(Color.primaryLabelColor)


### PR DESCRIPTION
Feat: Fix comment cell navigation error by deleting default blog id


커멘트 셀에 Blog.tempblog().id가 들어가있었어서 수정했습니다!